### PR TITLE
Pipeline: Upload data to timestamped schemas

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,14 +10,15 @@ nconf
       host: "scholar-reader.c5tvjmptvzlz.us-west-2.rds.amazonaws.com",
       port: 5432,
       database: "scholar-reader",
-      user: "api"
+      user: "api",
+      schema: "public"
     }
   });
 
 export const init = async (config: nconf.Provider) => {
   const server = new Server({
     port: 3000,
-    host: "0.0.0.0", 
+    host: "0.0.0.0",
     debug: {
       request: ["error"]
     }
@@ -31,7 +32,7 @@ export const init = async (config: nconf.Provider) => {
     }
   });
 
-  server.route({ method: 'GET', path: '/health', handler: () => '👍' })
+  server.route({ method: "GET", path: "/health", handler: () => "👍" });
 
   await server.start();
   console.log("Server running on %s", server.info.uri);

--- a/api/src/queries.ts
+++ b/api/src/queries.ts
@@ -81,7 +81,8 @@ export class Connection {
         password: config.get("database:password"),
         database: config.get("database:database"),
         ssl: true
-      }
+      },
+      searchPath: [config.get("database:schema")]
     });
   }
 

--- a/data-processing/explanations/parse_tex.py
+++ b/data-processing/explanations/parse_tex.py
@@ -298,9 +298,10 @@ class DocumentclassExtractor:
             if match.pattern.name == "UNKNOWN":
                 if match_stage == "awaiting-optional-arg":
                     return Documentclass(start, match.start)
-                return None
+                elif not match.text.isspace():
+                    break
 
-            if match_stage == "start":
+            elif match_stage == "start":
                 if match.pattern.name != "documentclass":
                     return None
                 start = match.start

--- a/data-processing/models/models.py
+++ b/data-processing/models/models.py
@@ -1,8 +1,11 @@
 import configparser
+from datetime import datetime
+from typing import Optional
 
 from peewee import (
     CharField,
     CompositeKey,
+    DatabaseProxy,
     DateTimeField,
     FloatField,
     ForeignKeyField,
@@ -19,21 +22,8 @@ config = configparser.ConfigParser()
 config.read(DATABASE_CONFIG)
 
 
-def init_database(
-    conf: configparser.ConfigParser, config_section: str
-) -> PostgresqlDatabase:
-    db_name = conf[config_section]["db_name"]
-    user = conf[config_section]["user"]
-    password = conf[config_section]["password"]
-    host = conf[config_section]["host"]
-    port = conf[config_section]["port"]
-    return PostgresqlDatabase(
-        db_name, user=user, password=password, host=host, port=port
-    )
-
-
-input_database = init_database(config, "input-db")
-output_database = init_database(config, "output-db")
+input_database = DatabaseProxy()
+output_database = DatabaseProxy()
 
 
 class InputModel(Model):  # type: ignore
@@ -156,10 +146,51 @@ class Annotation(BoundingBox):
     type = TextField(choices=(("citation", None), ("symbol", None)), index=True)
 
 
-def create_tables() -> None:
+def init_database(
+    conf: configparser.ConfigParser, config_section: str, schema: Optional[str] = None
+) -> PostgresqlDatabase:
     """
-    Initialize any tables that haven't yet been created.
+    Specify a default schema that the database should use for creating a querying tables with
+    the 'schema' parameter. This can allow you to upload data to development tables, rather
+    than the public schema which is queried by the live application.
     """
+
+    db_name = conf[config_section]["db_name"]
+    user = conf[config_section]["user"]
+    password = conf[config_section]["password"]
+    host = conf[config_section]["host"]
+    port = conf[config_section]["port"]
+
+    # Set the default schema for creating and querying tables by setting as the sole schema in the
+    # database connection's search path.
+    options = f'-c search_path="{schema}"' if schema is not None else ""
+    print(options)
+
+    return PostgresqlDatabase(
+        db_name, user=user, password=password, host=host, port=port, options=options,
+    )
+
+
+def init_database_connections(output_schema_name: Optional[str] = None) -> None:
+    """
+    Initialize database connections.
+    """
+
+    # By default, data will be placed in a schema with the timestamp of the time that this
+    # connection to the database was established.
+    if output_schema_name is None:
+        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        output_schema_name = f"schema_{timestamp}"
+
+    input_database.initialize(init_database(config, "input-db"))
+    output_database.initialize(init_database(config, "output-db", output_schema_name))
+
+    # Schema must be created before tables, because Peewee will attempt to create the tables
+    # within the schema.
+    output_database.execute_sql(
+        "CREATE SCHEMA IF NOT EXISTS %s" % (output_schema_name,)
+    )
+
     output_database.create_tables(
         [
             Paper,
@@ -175,5 +206,19 @@ def create_tables() -> None:
             EntityBoundingBox,
             Annotation,
         ],
+        # Don't create the tables if they're already created.
         safe=True,
+    )
+
+    output_database.execute_sql(
+        "GRANT USAGE ON SCHEMA %s TO %s" % (output_schema_name, "api")
+    )
+    output_database.execute_sql(
+        "GRANT SELECT ON ALL TABLES IN SCHEMA %s TO %s" % (output_schema_name, "api")
+    )
+    output_database.execute_sql(
+        "GRANT INSERT, UPDATE, DELETE ON TABLE %s TO %s" % ("annotation", "api")
+    )
+    output_database.execute_sql(
+        "GRANT SELECT, USAGE ON SEQUENCE %s TO %s" % ("annotation_id_seq", "api")
     )

--- a/data-processing/models/models.py
+++ b/data-processing/models/models.py
@@ -210,15 +210,13 @@ def init_database_connections(output_schema_name: Optional[str] = None) -> None:
         safe=True,
     )
 
+    # Provide 'api' user with read access to the new schema.
     output_database.execute_sql(
-        "GRANT USAGE ON SCHEMA %s TO %s" % (output_schema_name, "api")
+        "GRANT ALL ON SCHEMA %s TO %s" % (output_schema_name, "api")
     )
     output_database.execute_sql(
-        "GRANT SELECT ON ALL TABLES IN SCHEMA %s TO %s" % (output_schema_name, "api")
+        "GRANT ALL ON ALL TABLES IN SCHEMA %s TO %s" % (output_schema_name, "api")
     )
     output_database.execute_sql(
-        "GRANT INSERT, UPDATE, DELETE ON TABLE %s TO %s" % ("annotation", "api")
-    )
-    output_database.execute_sql(
-        "GRANT SELECT, USAGE ON SEQUENCE %s TO %s" % ("annotation_id_seq", "api")
+        "GRANT ALL ON ALL SEQUENCES IN SCHEMA %s TO %s" % (output_schema_name, "api")
     )

--- a/data-processing/scripts/command.py
+++ b/data-processing/scripts/command.py
@@ -5,6 +5,7 @@ from typing import Any, Generic, Iterator, List, Optional, TypeVar
 
 from explanations.directories import get_arxiv_ids
 from explanations.types import ArxivId, Path
+from models.models import init_database_connections
 
 I = TypeVar("I")
 R = TypeVar("R")
@@ -128,6 +129,29 @@ def read_arxiv_ids_from_file(path: Path) -> List[ArxivId]:
         raise SystemExit("Error: arXiv IDs %s file not found." % (path,))
     with open(path) as arxiv_ids_file:
         return [l.strip() for l in arxiv_ids_file.readlines()]
+
+
+class UploadCommand(ArxivBatchCommand[I, R], ABC):
+    """
+    A command for a batch job that uploads results to the output database. This command takes
+    care of initializing the databases and setting up a new schema in the database for the upload.
+    """
+
+    def __init__(self, args: Any) -> None:
+        super().__init__(args)
+        init_database_connections(output_schema_name=args.schema)
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        super(UploadCommand, UploadCommand).init_parser(parser)
+        parser.add_argument(
+            "--schema",
+            type=str,
+            help=(
+                "Name of schema to which data will be output. Defaults to the time at which this"
+                + " command object was created."
+            ),
+        )
 
 
 class Args:

--- a/data-processing/scripts/store_pipeline_log.py
+++ b/data-processing/scripts/store_pipeline_log.py
@@ -44,7 +44,7 @@ class StorePipelineLog(Command[None, None]):  # pylint: disable=unsubscriptable-
     def process(self, _: None) -> Iterator[None]:
         yield None
 
-    def save(self, item: None, _: None) -> None:
+    def save(self, _: None, __: None) -> None:
 
         upload_path = f"s3://{S3_BUCKET}/{self.args.s3_prefix}/logs/"
         command_args = [

--- a/data-processing/scripts/upload_citations.py
+++ b/data-processing/scripts/upload_citations.py
@@ -7,13 +7,22 @@ from typing import Dict, Iterator, List, NamedTuple, Tuple, cast
 from peewee import IntegrityError
 
 import explanations.directories as directories
-from explanations.directories import (get_data_subdirectory_for_iteration,
-                                      get_iteration_names)
+from explanations.directories import (
+    get_data_subdirectory_for_iteration,
+    get_iteration_names,
+)
 from explanations.types import ArxivId, Author, Path, PdfBoundingBox, Reference
-from models.models import (BoundingBox, Citation, CitationPaper, Entity,
-                           EntityBoundingBox, Paper, Summary,
-                           init_database_connections, output_database)
-from scripts.command import ArxivBatchCommand
+from models.models import (
+    BoundingBox,
+    Citation,
+    CitationPaper,
+    Entity,
+    EntityBoundingBox,
+    Paper,
+    Summary,
+    output_database,
+)
+from scripts.command import UploadCommand
 
 CitationKey = str
 CitationKeys = Tuple[CitationKey]
@@ -34,7 +43,7 @@ class CitationData(NamedTuple):
     s2_data: Dict[S2Id, Reference]
 
 
-class UploadCitations(ArxivBatchCommand[CitationData, None]):
+class UploadCitations(UploadCommand[CitationData, None]):
     """
     TODO(andrewhead): Ensure that the LaTeX compiler never produces more than one PDF. If so,
     we need to discover which PDF is the 'main' one that will get posted to arXiv.
@@ -175,8 +184,6 @@ class UploadCitations(ArxivBatchCommand[CitationData, None]):
         citations_by_hue_iteration = item.citations_by_hue_iteration
         key_s2_ids = item.key_s2_ids
         s2_data = item.s2_data
-
-        init_database_connections()
 
         try:
             paper = Paper.get(Paper.s2_id == s2_id)

--- a/data-processing/scripts/upload_citations.py
+++ b/data-processing/scripts/upload_citations.py
@@ -7,22 +7,12 @@ from typing import Dict, Iterator, List, NamedTuple, Tuple, cast
 from peewee import IntegrityError
 
 import explanations.directories as directories
-from explanations.directories import (
-    get_data_subdirectory_for_iteration,
-    get_iteration_names,
-)
+from explanations.directories import (get_data_subdirectory_for_iteration,
+                                      get_iteration_names)
 from explanations.types import ArxivId, Author, Path, PdfBoundingBox, Reference
-from models.models import (
-    BoundingBox,
-    Citation,
-    CitationPaper,
-    Entity,
-    EntityBoundingBox,
-    Paper,
-    Summary,
-    create_tables,
-    output_database,
-)
+from models.models import (BoundingBox, Citation, CitationPaper, Entity,
+                           EntityBoundingBox, Paper, Summary,
+                           init_database_connections, output_database)
 from scripts.command import ArxivBatchCommand
 
 CitationKey = str
@@ -186,7 +176,7 @@ class UploadCitations(ArxivBatchCommand[CitationData, None]):
         key_s2_ids = item.key_s2_ids
         s2_data = item.s2_data
 
-        create_tables()
+        init_database_connections()
 
         try:
             paper = Paper.get(Paper.s2_id == s2_id)

--- a/data-processing/scripts/upload_symbols.py
+++ b/data-processing/scripts/upload_symbols.py
@@ -6,22 +6,14 @@ from typing import Dict, Iterator, List, NamedTuple
 import explanations.directories as directories
 from explanations.file_utils import load_symbols
 from explanations.s2_data import get_s2_id
-from explanations.types import (
-    ArxivId,
-    Match,
-    Matches,
-    MathML,
-    Path,
-    PdfBoundingBox,
-    SymbolId,
-    SymbolWithId,
-)
+from explanations.types import (ArxivId, Match, Matches, MathML, Path,
+                                PdfBoundingBox, SymbolId, SymbolWithId)
 from models.models import BoundingBox, Entity, EntityBoundingBox
 from models.models import MathMl as MathMlModel
 from models.models import MathMlMatch, Paper
 from models.models import Symbol as SymbolModel
-from models.models import SymbolChild, init_database_connections, output_database
-from scripts.command import ArxivBatchCommand
+from models.models import SymbolChild, output_database
+from scripts.command import UploadCommand
 
 S2Id = str
 Hue = float
@@ -42,7 +34,7 @@ class SymbolData(NamedTuple):
     matches: Matches
 
 
-class UploadSymbols(ArxivBatchCommand[SymbolData, None]):
+class UploadSymbols(UploadCommand[SymbolData, None]):
     @staticmethod
     def get_name() -> str:
         return "upload-symbols"
@@ -124,8 +116,6 @@ class UploadSymbols(ArxivBatchCommand[SymbolData, None]):
         symbols_with_ids = item.symbols_with_ids
         boxes = item.boxes
         matches = item.matches
-
-        init_database_connections()
 
         try:
             paper = Paper.get(Paper.s2_id == s2_id)

--- a/data-processing/scripts/upload_symbols.py
+++ b/data-processing/scripts/upload_symbols.py
@@ -20,7 +20,7 @@ from models.models import BoundingBox, Entity, EntityBoundingBox
 from models.models import MathMl as MathMlModel
 from models.models import MathMlMatch, Paper
 from models.models import Symbol as SymbolModel
-from models.models import SymbolChild, create_tables, output_database
+from models.models import SymbolChild, init_database_connections, output_database
 from scripts.command import ArxivBatchCommand
 
 S2Id = str
@@ -125,7 +125,7 @@ class UploadSymbols(ArxivBatchCommand[SymbolData, None]):
         boxes = item.boxes
         matches = item.matches
 
-        create_tables()
+        init_database_connections()
 
         try:
             paper = Paper.get(Paper.s2_id == s2_id)


### PR DESCRIPTION
Sometimes, I want to create a "dev" copy of the database to test changes to the data pipeline in the UI, without impacting a clean master set of data in the dataset that everyone else is using for development and demos.

In this change, every time the data pipeline is run, it will upload data to a different schema (like a different namespace in Postgres), named by the time at which the pipeline was run (e.g., `schema_20191213_024444`). In the future, once we have validated that the data in a schema is high quality enough, it can be renamed to `public` to make it live in the UI.

This PR isn't _quite_ complete. I also want to make the schema name that data is uploaded to from the data processing scripts configurable (e.g., I can choose to always upload results to the "dev" schema). Though it is ready for high-level design feedback.