### PR TITLE
UI: Tooltip edges are now black

### DIFF
--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -10,7 +10,6 @@
  */
 @white: #fff;
 @black: #222;
-@border-color: #ccc;
 
 /**
  * HIGHLIGHTS
@@ -30,7 +29,7 @@
 /**
  * BORDERS
  */
-@border-color: #ddd;
+@border-color: @black;
 @border-width: 1px;
 @border-radius: 10px;
 @border: @border-width @border-color solid;


### PR DESCRIPTION
Changed original tooltip edges to now be black and also moved a variable redundancy in variables.less (repeating border-colors)

**Old**: 
<img width="465" alt="Screen Shot 2019-12-11 at 10 25 45 PM" src="https://user-images.githubusercontent.com/22308211/70853483-757ddd80-1e63-11ea-87d3-599fea778d1b.png">

**New**:
<img width="439" alt="Screen Shot 2019-12-11 at 10 25 28 PM" src="https://user-images.githubusercontent.com/22308211/70853490-82023600-1e63-11ea-8bc6-a7dada8757ba.png">

