### PR TITLE
UI: Symbol-only highlighting

### DIFF
--- a/ui/src/Annotation.tsx
+++ b/ui/src/Annotation.tsx
@@ -16,6 +16,7 @@ interface AnnotationProps {
   location: BoundingBox;
   tooltipContent: React.ReactNode;
   onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  highlighted?: Boolean | false;
 }
 
 interface AnnotationState {
@@ -94,7 +95,8 @@ export class Annotation extends React.Component<
                     "scholar-reader-annotation",
                     this.props.className,
                     {
-                      selected: this.isSelected()
+                      selected: this.isSelected(),
+                      "annotation-highlighted": this.props.highlighted,
                     }
                   )}
                   tabIndex={0}

--- a/ui/src/CitationAnnotation.tsx
+++ b/ui/src/CitationAnnotation.tsx
@@ -20,6 +20,7 @@ export class CitationAnnotation extends React.Component<
         tooltipContent={
           <CitationTooltipBody paperIds={this.props.citation.papers} />
         }
+        highlighted={false}
       />
     );
   }

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -58,6 +58,8 @@ class ScholarReader extends React.Component<ScholarReaderProps, State> {
       setJumpPaperId: this.setJumpPaperId.bind(this),
       selectedSymbol: null,
       setSelectedSymbol: this.setSelectedSymbol.bind(this),
+      highlightedSymbols: new Set(),
+      setHighlightedSymbols: this.setHighlightedSymbols.bind(this),
       jumpSymbol: null,
       setJumpSymbol: this.setJumpSymbol.bind(this),
       userAnnotationsEnabled: false,
@@ -115,6 +117,10 @@ class ScholarReader extends React.Component<ScholarReaderProps, State> {
 
   setSelectedSymbol(symbol: Symbol | null) {
     this.setState({ selectedSymbol: symbol });
+  }
+
+  setHighlightedSymbols(symbolIds: Set<number>) {
+    this.setState({ highlightedSymbols: symbolIds });
   }
 
   setJumpSymbol(symbol: Symbol | null) {

--- a/ui/src/SymbolAnnotation.tsx
+++ b/ui/src/SymbolAnnotation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Annotation from "./Annotation";
 import SymbolTooltipBody from "./SymbolTooltipBody";
+import { ScholarReaderContext } from "./state";
 import { BoundingBox, Symbol } from "./types/api";
 
 interface SymbolAnnotationProps {
@@ -11,13 +12,33 @@ interface SymbolAnnotationProps {
 export class SymbolAnnotation extends React.Component<SymbolAnnotationProps> {
   render() {
     return (
-      <div hidden={this.props.symbol.parent !== null}>
-        <Annotation
-          id={`symbol-${this.props.symbol.id}-annotation`}
-          location={this.props.location}
-          tooltipContent={<SymbolTooltipBody symbol={this.props.symbol} />}
-        />
-      </div>
+      <ScholarReaderContext.Consumer>
+        {({ highlightedSymbols, symbols, mathMl, setHighlightedSymbols }) => {
+          return (
+            <div hidden={this.props.symbol.parent !== null}>
+              <Annotation
+                id={`symbol-${this.props.symbol.id}-annotation`}
+                location={this.props.location}
+                tooltipContent={
+                  <SymbolTooltipBody 
+                    symbol={this.props.symbol} 
+                    symbols={[...symbols]}
+                    mathMl={[...mathMl]}
+                    setHighlightedSymbols={setHighlightedSymbols}
+                    clearHighlightedSymbols={() => 
+                      /* only clear symbols if another annotation was not
+                       * opened somewhere else. */
+                      highlightedSymbols.has(this.props.symbol.id)
+                      && setHighlightedSymbols(new Set())
+                    }
+                  />
+                }
+                highlighted={highlightedSymbols.has(this.props.symbol.id)}
+              />
+            </div>
+          );
+        }}
+      </ScholarReaderContext.Consumer>
     );
   }
 }

--- a/ui/src/selectors/symbol.ts
+++ b/ui/src/selectors/symbol.ts
@@ -25,6 +25,20 @@ export function matchingSymbols(
 }
 
 /**
+ * Return a set of matching symbolIds
+ */
+export function matchingSymbolIds(
+  symbol: Symbol,
+  symbols: Symbol[],
+  allMathMl: MathMl[]
+) {
+  return new Set(
+    matchingSymbols(symbol, symbols, allMathMl).map(s => s.id)
+  );
+}
+
+
+/**
  * Get the first symbol from the set with exactly-matching MathML.
  */
 export function firstMatchingSymbol(symbol: Symbol, symbols: Symbol[]) {

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -43,6 +43,8 @@ export interface State {
   setJumpPaperId(s2Id: string | null): void;
   selectedSymbol: Symbol | null;
   setSelectedSymbol(symbol: Symbol | null): void;
+  highlightedSymbols: Set<number>;
+  setHighlightedSymbols(symbolIds: Set<number>): void;
   jumpSymbol: Symbol | null;
   setJumpSymbol(symbol: Symbol | null): void;
   selectedAnnotationId: string | null;
@@ -99,6 +101,8 @@ const defaultState: State = {
   setJumpPaperId: () => {},
   selectedSymbol: null,
   setSelectedSymbol: () => {},
+  highlightedSymbols: new Set(),
+  setHighlightedSymbols: () => {},
   jumpSymbol: null,
   setJumpSymbol: () => {},
   userAnnotationsEnabled: false,

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -22,6 +22,13 @@
 }
 
 /**
+* Highlighted Annotations
+*/
+.annotation-highlighted {
+  border-color: @red !important;
+}
+
+/**
  * Highlight the area of an annotation on hover
  */
 .scholar-reader-annotation:not(.user-annotation) {
@@ -31,3 +38,4 @@
     cursor: pointer;
   }
 }
+

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -11,6 +11,7 @@
  */
 @white: #fff;
 @black: #222;
+@red: #f50057;
 
 @citation-user-annotation-color: #2a2;
 @symbol-user-annotation-color: #d5d;


### PR DESCRIPTION
Clicking on a symbol now highlights (changes the underline to red) for all other matching symbols. 

Open to discussing different ways of highlighting the symbols, just wanted to get something that could be demoed. Also, thinking about switching over to the annotation id's now that those exist (might take a performance hit from doing that tho).

Additionally, wanted to talk about the performance hit that we take from implementing this since we can't update the underline without also re-rending every single onscreen annotation which can be an issue with symbol heavy pages. 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22308211/70869232-b0ecda80-1f3d-11ea-8b13-6b47d15bbd01.gif)