### PR TITLE
Show a small snippet of the abstract in the citation tooltip.

### DIFF
--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import AuthorList from "./AuthorList";
 import { ScholarReaderContext } from "./state";
+import { truncateText } from "./ui-utils";
 
 interface CitationProperties {
   paperId: string;
@@ -20,6 +21,11 @@ export class Citation extends React.Component<CitationProperties> {
                   by <AuthorList authors={paper.authors} />
                 </>
               )}
+              {paper.abstract !== null ? (
+                <div className="citation__abstract">
+                  {truncateText(paper.abstract, 110)}
+                </div>
+              ) : null}
             </div>
           );
         }}

--- a/ui/src/CitationTooltipBody.tsx
+++ b/ui/src/CitationTooltipBody.tsx
@@ -33,6 +33,7 @@ export class CitationTooltipBody extends React.Component<
                     disableGutters
                     key={s2Id}
                     button
+                    className="tooltip-body__citation"
                     onClick={() => {
                       setSelectedCitation(this.props.citation);
                       setDrawerState("show-citations");

--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -9,8 +9,7 @@ import CiteIcon from "@material-ui/icons/FormatQuote";
 import InfluentialCitationIcon from "./icon/InfluentialCitationIcon";
 import ChartIcon from "./icon/ChartIcon";
 import Tooltip from "@material-ui/core/Tooltip";
-
-const TRUNCATED_ABSTRACT_LENGTH = 300;
+import { truncateText } from "./ui-utils";
 
 function warnOfUnimplementedActionAndTrack(actionType: string) {
   alert("Sorry, that feature isn't implemented yet. Clicking it tells us " +
@@ -49,6 +48,7 @@ export class PaperSummary extends React.Component<
         {({ papers, jumpPaperId, setJumpPaperId }) => {
           const paper = papers[this.props.paperId];
           const hasMetrics = paper.citationVelocity !== 0 || paper.influentialCitationCount !== 0;
+          const truncatedAbstract = paper.abstract ? truncateText(paper.abstract, 300) : null;
           return (
             <div
               ref={ref => {
@@ -78,12 +78,11 @@ export class PaperSummary extends React.Component<
                 <div className="paper-summary__section">
                   <p className="paper-summary__abstract">
                     {this.state.showFullAbstract ||
-                    paper.abstract.length < TRUNCATED_ABSTRACT_LENGTH ? (
+                    truncatedAbstract === paper.abstract ? (
                       paper.abstract
                     ) : (
                       <>
-                        {paper.abstract.substr(0, TRUNCATED_ABSTRACT_LENGTH) +
-                          "..."}
+                        {truncatedAbstract}
                         <span
                           className="paper-summary__abstract__show-more-label"
                           onClick={() => {

--- a/ui/src/style/citation.less
+++ b/ui/src/style/citation.less
@@ -4,3 +4,8 @@
 .citation .title {
   font-weight: bolder;
 }
+
+.citation__abstract {
+  display: block;
+  margin: @medium / 2 0 0;
+}

--- a/ui/src/style/paper-summary.less
+++ b/ui/src/style/paper-summary.less
@@ -100,3 +100,7 @@
   font-size: 1.125rem;
   font-weight: 700;
 }
+
+.paper-summary__abstract__show-more-label {
+  cursor: pointer;
+}

--- a/ui/src/style/tooltip.less
+++ b/ui/src/style/tooltip.less
@@ -36,6 +36,17 @@
     grid-gap: @medium * 0.5;
     align-items: center;
   }
+
+
+  /**
+   * Adding a small amount of horizontal padding to citations so that there's
+   * some separation between the hover state background color and the left and
+   * right edges of the text.
+   */
+  .tooltip-body__citation {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
 }
 
 /**

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -29,6 +29,9 @@ const ELLIPSIS = '…';
  * ellipsis upon truncation by default.  If the text is shorter than the provided limit, the full
  * text is returned.
  *
+ * This method was ported from Semantic Scholar's UI codebase. It's a UI
+ * utility.
+ *
  * @param {string} text The text to truncate.
  * @param {number} limit The maximum number of characters to show.
  * @param {boolean} whether to include an ellipsis after the truncation, defaults to true

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -19,3 +19,45 @@ export function isKeypressEscape(event: React.KeyboardEvent | KeyboardEvent) {
   }
   return false;
 }
+
+const PATTERN_NON_WORD_CHAR = /\W/;
+const PATTERN_WORD_CHAR = /\w/;
+const ELLIPSIS = '…';
+
+/**
+ * Truncates the provided text such that no more than limit characters are rendered and adds an
+ * ellipsis upon truncation by default.  If the text is shorter than the provided limit, the full
+ * text is returned.
+ *
+ * @param {string} text The text to truncate.
+ * @param {number} limit The maximum number of characters to show.
+ * @param {boolean} whether to include an ellipsis after the truncation, defaults to true
+ *
+ * @return {string} the truncated text, or full text if it's shorter than the provided limit.
+ */
+export function truncateText(text: string, limit: number, withEllipsis: boolean = true): string {
+  if (typeof limit !== 'number') {
+    throw new Error('limit must be a number');
+  }
+
+  if (withEllipsis) {
+    limit -= ELLIPSIS.length;
+  }
+
+  if (text.length > limit) {
+    while (
+      limit > 1 &&
+      (!PATTERN_WORD_CHAR.test(text[limit-1]) || !PATTERN_NON_WORD_CHAR.test(text[limit]))
+    ) {
+      limit -= 1;
+    }
+    if (limit === 1) {
+      return text;
+    } else {
+      const truncatedText = text.substring(0, limit);
+      return withEllipsis ? truncatedText + ELLIPSIS : truncatedText + '.';
+    }
+  } else {
+    return text;
+  }
+}


### PR DESCRIPTION
This modifies the citation tooltip so that a small snippet from the
abstract id displayed. The limit I set (110 characters) is roughly
2 lines of text, which is what felt natural to me.

In doing this I ported over Semantic Scholar's text truncation
mechanism, as it tries to avoid truncating mid-word and uses the
`utf-8` ellipsis character.

![image](https://user-images.githubusercontent.com/801451/70938916-05568f80-1ffc-11ea-89b9-20db7d7ee45e.png)
