### PR TITLE
Close the drawer on escape.

### DIFF
--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -203,16 +203,30 @@ class ScholarReader extends React.Component<ScholarReaderProps, State> {
     this.setState({ userAnnotations: annotations });
   }
 
+  closeDrawerOnEscape = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      this.setDrawerState("closed");
+    }
+  }
+
+  toggleUserAnnotationState = (event: KeyboardEvent) => {
+    if (event.ctrlKey && event.shiftKey && event.key !== "a") {
+      this.setUserAnnotationsEnabled(!this.state.userAnnotationsEnabled);
+    }
+  }
+
   async componentDidMount() {
     waitForPDFViewerInitialization().then(application => {
       this.subscribeToPDFViewerStateChanges(application);
     });
     this.loadDataFromApi();
-    document.onkeypress = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.shiftKey && e.key !== "a") {
-        this.setUserAnnotationsEnabled(!this.state.userAnnotationsEnabled);
-      }
-    };
+    window.addEventListener('keypress', this.toggleUserAnnotationState);
+    window.addEventListener('keydown', this.closeDrawerOnEscape);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keypress', this.toggleUserAnnotationState);
+    window.removeEventListener('keydown', this.closeDrawerOnEscape);
   }
 
   subscribeToPDFViewerStateChanges(pdfViewerApplication: PDFViewerApplication) {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -27,6 +27,7 @@ import {
   PDFViewerApplication
 } from "./types/pdfjs-viewer";
 import FeedbackButton from "./FeedbackButton";
+import { isKeypressEscape } from "./ui-utils";
 
 interface ScholarReaderProps {
   paperId?: PaperId;
@@ -204,7 +205,7 @@ class ScholarReader extends React.Component<ScholarReaderProps, State> {
   }
 
   closeDrawerOnEscape = (event: KeyboardEvent) => {
-    if (event.key === "Escape") {
+    if (isKeypressEscape(event)) {
       this.setDrawerState("closed");
     }
   }

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -7,7 +7,7 @@ export function getMouseXY(event: React.MouseEvent) {
   return { x, y };
 }
 
-export function isKeypressEscape(event: React.KeyboardEvent) {
+export function isKeypressEscape(event: React.KeyboardEvent | KeyboardEvent) {
   if (
     event.key !== undefined &&
     (event.key === "Esc" || event.key === "Escape")


### PR DESCRIPTION
This adds code that closes the drawer if the escape key is pressed.
This felt like a nice convenience, and conveniently required very
little code.

I also revised the annotation event handler to use the same mechanism
for binding and removing events. We don't actively mount / remount
the top level `<ScholarReader />`, so there's no active motivator --
but in case we ever do it'll ensure things get added and removed properly.