### PR TITLE
UI : Re-style citation and symbol underlines

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -71,7 +71,7 @@ To use a local version of the API, export the `PROXY` environment
 variable like so:
 
 ```bash
-export PROXY='http://localhost:3001'
+export PROXY='http://localhost:3000'
 ```
 
 See the README in the `api/` sibling directory for more information

--- a/ui/src/selectors/annotation.ts
+++ b/ui/src/selectors/annotation.ts
@@ -11,6 +11,8 @@ export function divDimensionStyles(pageView: PDFPageView, box: BoundingBox) {
    * location detection in the data processing scripts?
    */
   const SCALE_CORRECTION = 0.9975;
+  const HEIGHT_CORRECTION = -2;
+  const WIDTH_CORRECTION = -2;
   const viewport = pageView.pdfPage.getViewport({
     scale: pageView.viewport.scale * SCALE_CORRECTION
   });
@@ -23,10 +25,10 @@ export function divDimensionStyles(pageView: PDFPageView, box: BoundingBox) {
    * https://github.com/wojtekmaj/react-pdf/blob/73f505eca1bf1ae243a2b7068fce1e86b98b408a/src/Page/AnnotationLayer.jsx#L104
    */
   return {
-    left: viewportBox[0],
+    left: viewportBox[0] - WIDTH_CORRECTION,
     top: viewportBox[1],
-    width: viewportBox[2] - viewportBox[0],
-    height: viewportBox[1] - viewportBox[3]
+    width: viewportBox[2] - viewportBox[0] + (2 * WIDTH_CORRECTION),
+    height: viewportBox[1] - viewportBox[3] + HEIGHT_CORRECTION
   };
 }
 

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -17,7 +17,7 @@
  * Provide an underline as the default indicator of an annotation
  */
 .scholar-reader-annotation:not(.user-annotation) {
-  border-bottom: @underline-width @underline-color solid;
+  border-bottom: @underline-width @underline-color dotted;
   padding-bottom: @underline-offset;
 }
 

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -29,7 +29,7 @@
  */
 @underline-offset: 5px;
 @underline-width: 2px;
-@underline-color: #aaf;
+@underline-color: #333;
 
 /**
  * BORDERS


### PR DESCRIPTION
I've made the following changes

- Recolour the underline to "#333"
- Restyle the underline to "dotted" from "solid"
- Correct a bug in the ui Readme file
- Add height and width corrections to the bounding boxes for annotations
