### PR TITLE
Faster version of Symbol Highlights

### DIFF
--- a/ui/src/Annotation.tsx
+++ b/ui/src/Annotation.tsx
@@ -21,7 +21,7 @@ interface AnnotationProps {
   source?: string;
   className?: string;
   location: BoundingBox;
-  shouldHighlight?: boolean | false;
+  shouldHighlight?: boolean;
   /**
    * Correction factor to apply to bounding box coordinates before rendering the annotation.
    * You normally should not need to set this and should be able to trust the defaults.
@@ -39,6 +39,9 @@ export class Annotation extends React.PureComponent<
   AnnotationProps,
   AnnotationState
 > {
+  static defaultProps = {
+    shouldHighlight: false,
+  }
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 

--- a/ui/src/Annotation.tsx
+++ b/ui/src/Annotation.tsx
@@ -41,11 +41,6 @@ export class Annotation extends React.PureComponent<
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 
-  constructor(props: AnnotationProps) {
-    super(props);
-    this.state = { selected: false };
-  }
-
   onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     if (uiUtils.isKeypressEscape(e)) {
       this.deselectIfSelected();
@@ -61,6 +56,20 @@ export class Annotation extends React.PureComponent<
 
   select() {
     this.context.setSelectedAnnotationId(this.props.id);
+  }
+
+  shouldHighlight() {
+    if (!this.context.selectedAnnotationId) { return false; }
+    const [typeSelected, idSelected,] = this.context.selectedAnnotationId.split('-');
+    const [typeSelf, idSelf,] = this.props.id.split('-');
+    if (typeSelf !== typeSelected) { return false; }
+    
+    // We are only focusing on symbols for right now;
+    if (typeSelf === 'symbol') {
+      const highlightedIds = this.context.symbolMatchSet[Number(idSelected)];
+      return this.isSelected() || highlightedIds.has(Number(idSelf));
+    }
+    return false;
   }
 
   deselectIfSelected() {
@@ -110,7 +119,8 @@ export class Annotation extends React.PureComponent<
                       selected: this.isSelected(),
                       "source-tex-pipeline":
                         this.props.source === "tex-pipeline",
-                      "source-other": this.props.source === "other"
+                      "source-other": this.props.source === "other",
+                      "annotation-highlight": this.shouldHighlight(),
                     }
                   )}
                   tabIndex={0}

--- a/ui/src/Annotation.tsx
+++ b/ui/src/Annotation.tsx
@@ -21,6 +21,7 @@ interface AnnotationProps {
   source?: string;
   className?: string;
   location: BoundingBox;
+  shouldHighlight?: boolean | false;
   /**
    * Correction factor to apply to bounding box coordinates before rendering the annotation.
    * You normally should not need to set this and should be able to trust the defaults.
@@ -56,20 +57,6 @@ export class Annotation extends React.PureComponent<
 
   select() {
     this.context.setSelectedAnnotationId(this.props.id);
-  }
-
-  shouldHighlight() {
-    if (!this.context.selectedAnnotationId) { return false; }
-    const [typeSelected, idSelected,] = this.context.selectedAnnotationId.split('-');
-    const [typeSelf, idSelf,] = this.props.id.split('-');
-    if (typeSelf !== typeSelected) { return false; }
-    
-    // We are only focusing on symbols for right now;
-    if (typeSelf === 'symbol') {
-      const highlightedIds = this.context.symbolMatchSet[Number(idSelected)];
-      return this.isSelected() || highlightedIds.has(Number(idSelf));
-    }
-    return false;
   }
 
   deselectIfSelected() {
@@ -120,7 +107,7 @@ export class Annotation extends React.PureComponent<
                       "source-tex-pipeline":
                         this.props.source === "tex-pipeline",
                       "source-other": this.props.source === "other",
-                      "annotation-highlight": this.shouldHighlight(),
+                      "matching-symbol-annotation": this.props.shouldHighlight,
                     }
                   )}
                   tabIndex={0}

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -354,7 +354,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
            * Build a mapping from symbol to all possible parent matches
            */
           const symbolMatchSet: SymbolMatchSet = {};
-          symbols.map(s => {
+          symbols.forEach(s => {
             symbolMatchSet[s.id] = new Set(
               selectors.matchingSymbols(s, symbols, mathMl)
               .map(m => {

--- a/ui/src/SymbolAnnotation.tsx
+++ b/ui/src/SymbolAnnotation.tsx
@@ -17,10 +17,10 @@ export class SymbolAnnotation extends React.PureComponent<SymbolAnnotationProps>
 
   shouldHighlight() {
     if (!this.context.selectedAnnotationId) { return false; }
-    const [typeSelected, idSelected,] = this.context.selectedAnnotationId.split('-');
+    const [typeSelected, idSelected] = this.context.selectedAnnotationId.split('-');
     if (typeSelected !== 'symbol') { return false; }
     
-    const matchingSymbolIds = this.context.symbolMatchSet[Number(idSelected)];
+    const matchingSymbolIds = this.context.symbolMatches[Number(idSelected)];
     return matchingSymbolIds.has(this.props.symbol.id);
   }
 

--- a/ui/src/SymbolAnnotation.tsx
+++ b/ui/src/SymbolAnnotation.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React from "react";
 import Annotation from "./Annotation";
 import SymbolTooltipBody from "./SymbolTooltipBody";
+import { ScholarReaderContext } from "./state";
 import { BoundingBox, Symbol } from "./types/api";
 
 interface SymbolAnnotationProps {
@@ -10,9 +11,19 @@ interface SymbolAnnotationProps {
   showHint?: boolean;
 }
 
-export class SymbolAnnotation extends React.PureComponent<
-  SymbolAnnotationProps
-> {
+export class SymbolAnnotation extends React.PureComponent<SymbolAnnotationProps> {
+  static contextType = ScholarReaderContext;
+  context!: React.ContextType<typeof ScholarReaderContext>;
+
+  shouldHighlight() {
+    if (!this.context.selectedAnnotationId) { return false; }
+    const [typeSelected, idSelected,] = this.context.selectedAnnotationId.split('-');
+    if (typeSelected !== 'symbol') { return false; }
+    
+    const matchingSymbolIds = this.context.symbolMatchSet[Number(idSelected)];
+    return matchingSymbolIds.has(this.props.symbol.id);
+  }
+
   render() {
     return (
       <div hidden={this.props.symbol.parent !== null}>
@@ -22,6 +33,7 @@ export class SymbolAnnotation extends React.PureComponent<
           source={this.props.symbol.source}
           location={this.props.location}
           tooltipContent={<SymbolTooltipBody symbol={this.props.symbol} />}
+          shouldHighlight={this.shouldHighlight()}
         />
       </div>
     );

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -1,7 +1,7 @@
 import { PDFDocumentProxy } from "pdfjs-dist";
 import React from "react";
 import { FavoritableId } from "./FavoriteButton";
-import { Annotation, AnnotationData, Citation, MathMl, Paper, Symbol, SymbolMatchSet, UserLibrary } from "./types/api";
+import { Annotation, AnnotationData, Citation, MathMl, Paper, Symbol, symbolMatches, UserLibrary } from "./types/api";
 import { PDFPageView, PDFViewer } from "./types/pdfjs-viewer";
 
 export interface State {
@@ -13,8 +13,8 @@ export interface State {
   setCitations(citations: Citation[]): void;
   symbols: Readonly<Symbol[]>;
   setSymbols(symbols: Symbol[]): void;
-  symbolMatchSet: Readonly<SymbolMatchSet>;
-  setSymbolMatchSet(matchSet: SymbolMatchSet): void;
+  symbolMatches: Readonly<symbolMatches>;
+  setSymbolMatches(matchSet: symbolMatches): void;
   mathMl: Readonly<MathMl[]>;
   setMathMl(mathMl: MathMl[]): void;
   papers: Readonly<Papers>;
@@ -94,8 +94,8 @@ const defaultState: State = {
   setCitations: () => {},
   symbols: [],
   setSymbols: () => {},
-  symbolMatchSet: {},
-  setSymbolMatchSet: () => {},
+  symbolMatches: {},
+  setSymbolMatches: () => {},
   mathMl: [],
   setMathMl: () => {},
   papers: {},

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -1,15 +1,7 @@
 import { PDFDocumentProxy } from "pdfjs-dist";
 import React from "react";
 import { FavoritableId } from "./FavoriteButton";
-import {
-  Annotation,
-  AnnotationData,
-  Citation,
-  MathMl,
-  Paper,
-  Symbol,
-  UserLibrary
-} from "./types/api";
+import { Annotation, AnnotationData, Citation, MathMl, Paper, Symbol, SymbolMatchSet, UserLibrary } from "./types/api";
 import { PDFPageView, PDFViewer } from "./types/pdfjs-viewer";
 
 export interface State {
@@ -21,6 +13,8 @@ export interface State {
   setCitations(citations: Citation[]): void;
   symbols: Readonly<Symbol[]>;
   setSymbols(symbols: Symbol[]): void;
+  symbolMatchSet: Readonly<SymbolMatchSet>;
+  setSymbolMatchSet(matchSet: SymbolMatchSet): void;
   mathMl: Readonly<MathMl[]>;
   setMathMl(mathMl: MathMl[]): void;
   papers: Readonly<Papers>;
@@ -100,6 +94,8 @@ const defaultState: State = {
   setCitations: () => {},
   symbols: [],
   setSymbols: () => {},
+  symbolMatchSet: {},
+  setSymbolMatchSet: () => {},
   mathMl: [],
   setMathMl: () => {},
   papers: {},

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -20,21 +20,22 @@
   border-bottom: @underline-width @underline-color dotted;
 }
 
-/**
- * Provide an underline as a hint that the annotation is interactive 
- */
-.scholar-reader-annotation.annotation-highlight {
-  border-bottom: @underline-width+1px @annotation-highlight-color solid;
-}
 
-/**
- * Highlight the area of an annotation on hover
- */
 .scholar-reader-annotation:not(.user-annotation) {
+  /**
+  * Highlight the area of an annotation on hover
+  */
   &:hover,
   &.selected {
     background-color: @highlight-color;
     cursor: pointer;
+  }
+  /**
+  * Highlight all matching symbols
+  */
+  &.matching-symbol-annotation,
+  &.selected {
+    border-bottom: @underline-width+1px @highlight solid;
   }
 }
 

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -35,7 +35,7 @@
   */
   &.matching-symbol-annotation,
   &.selected {
-    border-bottom: @underline-width+1px @highlight solid;
+    border-bottom: @underline-width+1px @highlight-annotation-color solid;
   }
 }
 

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -21,6 +21,13 @@
 }
 
 /**
+ * Provide an underline as a hint that the annotation is interactive 
+ */
+.scholar-reader-annotation.annotation-highlight {
+  border-bottom: @underline-width+1px @annotation-highlight-color solid;
+}
+
+/**
  * Highlight the area of an annotation on hover
  */
 .scholar-reader-annotation:not(.user-annotation) {

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -33,7 +33,7 @@
 @highlight-border-color: #88f;
 @highlight-hover-opacity: 0.2;
 @highlight-hitbox-padding: .1em;
-@annotation-highlight-color: @s2-influential-citation-orange;
+@highlight: @s2-influential-citation-orange;
 /**
  * TEXT STYLING
  */

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -33,7 +33,7 @@
 @highlight-border-color: #88f;
 @highlight-hover-opacity: 0.2;
 @highlight-hitbox-padding: .1em;
-@highlight: @s2-influential-citation-orange;
+@highlight-annotation-color: @s2-influential-citation-orange;
 /**
  * TEXT STYLING
  */

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -15,7 +15,6 @@
 
 @citation-user-annotation-color: #2a2;
 @symbol-user-annotation-color: #d5d;
-
 /**
  * S2 COLORS
  */
@@ -34,14 +33,13 @@
 @highlight-border-color: #88f;
 @highlight-hover-opacity: 0.2;
 @highlight-hitbox-padding: .1em;
-
+@annotation-highlight-color: @s2-influential-citation-orange;
 /**
  * TEXT STYLING
  */
 @underline-offset: 5px;
 @underline-width: 1px;
 @underline-color: #333;
-
 /**
  * BORDERS
  */

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -47,7 +47,7 @@ export interface Symbol {
   children: number[];
 }
 
-export interface SymbolMatchSet {
+export interface symbolMatches {
   [id: number]: Set<number>;
 }
 

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -47,6 +47,10 @@ export interface Symbol {
   children: number[];
 }
 
+export interface SymbolMatchSet {
+  [id: number]: Set<number>;
+}
+
 export interface MathMl {
   mathMl: string;
   matches: MathMlMatch[];


### PR DESCRIPTION
This is an optimization using strategies @andrewhead and I talked about to speed up symbol annotation highlighting. It now adds no perceivable costs to the annotation tooltip opening. The highlighting of in the video is just a placeholder so it's easier to see on the gif. Haven't really decided on a highlighting for the actual implementation (right now it's just the s2-influential-citation-orange but opening to suggestions.
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/22308211/71431630-0e90cd80-2688-11ea-8226-49f34f5d2424.gif)
 