### PR TITLE
Save to library functionality

### DIFF
--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -11,6 +11,7 @@ import S2Link from "./S2Link";
 import { ScholarReaderContext } from "./state";
 import { truncateText } from "./ui-utils";
 import {userLibraryUrl} from "./s2-url";
+import {UserLibrary} from "./types/api";
 
 function warnOfUnimplementedActionAndTrack(actionType: string) {
   alert("Sorry, that feature isn't implemented yet. Clicking it tells us " +
@@ -72,6 +73,24 @@ export class PaperSummary extends React.PureComponent<
         {label}
       </Button>
     )
+  }
+
+  async saveToLibrary(userLibrary: UserLibrary | null, addToLibrary: Function, paperTitle: string) {
+    if (!userLibrary) {
+      warnOfUnimplementedActionAndTrack('save');
+    } else {
+      try {
+        await addToLibrary(this.props.paperId, paperTitle);
+        trackLibrarySave();
+        this.setState({
+          errorMessage: ''
+        })
+      } catch (error) {
+        this.setState({
+          errorMessage: 'Cannot save to library at this time.'
+        })
+      }
+    }
   }
 
   render() {
@@ -174,23 +193,7 @@ export class PaperSummary extends React.PureComponent<
                     Cite
                   </Button>
                   {inLibrary ? this.renderLibraryButton('In Your Library', () => goToLibrary())
-                      : this.renderLibraryButton('Save To Library', async() => {
-                        if (!userLibrary) {
-                          warnOfUnimplementedActionAndTrack('save');
-                        } else {
-                          try {
-                            await addToLibrary(this.props.paperId, paper.title);
-                            trackLibrarySave();
-                            this.setState({
-                              errorMessage: ''
-                            })
-                          } catch (error) {
-                            this.setState({
-                              errorMessage: 'Cannot save to library at this time.'
-                            })
-                          }
-                        }
-                      })
+                      : this.renderLibraryButton('Save To Library', () => this.saveToLibrary(userLibrary, addToLibrary, paper.title))
                   }
               </div>
               <FavoriteButton

--- a/ui/src/s2-url.ts
+++ b/ui/src/s2-url.ts
@@ -1,0 +1,6 @@
+
+const utmSource = '?utm_source=augmented_reader';
+
+export const userInfoUrl = 'https://www.semanticscholar.org/api/1/user' + utmSource;
+export const userLibraryUrl = 'https://www.semanticscholar.org/me/library' + utmSource;
+export const addLibraryEntryUrl = 'https://www.semanticscholar.org/api/1/library/entries' + utmSource;

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -29,7 +29,6 @@ export interface State {
   /*
    * USER DATA
    */
-  userId?: number,
   userLibrary: UserLibrary | null;
 
   /*
@@ -69,7 +68,6 @@ export interface State {
   deleteUserAnnotation(id: number): void;
   setUserAnnotations(annotations: Annotation[]): void;
   setUserLibrary(userLibrary: UserLibrary | null): void;
-  setUserId(userId: number): void;
   addToLibrary(paperId: string, paperTitle: string): void;
 }
 
@@ -95,9 +93,7 @@ export interface PaperId {
 
 const defaultState: State = {
   paperId: undefined,
-  userId: undefined,
   userLibrary: null,
-  setUserId: () => {},
   setUserLibrary: () => {},
   addToLibrary: () => {},
   citations: [],

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -1,7 +1,15 @@
 import { PDFDocumentProxy } from "pdfjs-dist";
 import React from "react";
 import { FavoritableId } from "./FavoriteButton";
-import { Annotation, AnnotationData, Citation, MathMl, Paper, Symbol } from "./types/api";
+import {
+  Annotation,
+  AnnotationData,
+  Citation,
+  MathMl,
+  Paper,
+  Symbol,
+  UserLibrary
+} from "./types/api";
 import { PDFPageView, PDFViewer } from "./types/pdfjs-viewer";
 
 export interface State {
@@ -17,6 +25,12 @@ export interface State {
   setMathMl(mathMl: MathMl[]): void;
   papers: Readonly<Papers>;
   setPapers(papers: Papers): void;
+
+  /*
+   * USER DATA
+   */
+  userId?: number,
+  userLibrary: UserLibrary | null;
 
   /*
    * PDF VIEWER STATE
@@ -54,6 +68,9 @@ export interface State {
   updateUserAnnotation(id: number, annotation: Annotation): void;
   deleteUserAnnotation(id: number): void;
   setUserAnnotations(annotations: Annotation[]): void;
+  setUserLibrary(userLibrary: UserLibrary | null): void;
+  setUserId(userId: number): void;
+  addToLibrary(paperId: string, paperTitle: string): void;
 }
 
 export type Papers = { [s2Id: string]: Paper };
@@ -78,6 +95,11 @@ export interface PaperId {
 
 const defaultState: State = {
   paperId: undefined,
+  userId: undefined,
+  userLibrary: null,
+  setUserId: () => {},
+  setUserLibrary: () => {},
+  addToLibrary: () => {},
   citations: [],
   setCitations: () => {},
   symbols: [],

--- a/ui/src/style/paper-summary.less
+++ b/ui/src/style/paper-summary.less
@@ -73,6 +73,10 @@
   }
 }
 
+.paper-summary__library-error {
+  color: @s2-error;
+}
+
 /**
  * Metrics
  */

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -25,6 +25,7 @@
 @s2-text-light: #8c9296;
 @s2-border-light: #e0e0e0;
 @s2-influential-citation-orange: #dd913f;
+@s2-error: #ff0000;
 
 /**
  * HIGHLIGHTS

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -65,3 +65,21 @@ export interface AnnotationData {
 export interface Annotation extends AnnotationData {
   id: AnnotationId;
 }
+
+
+export interface UserInfo {
+  user: {
+    id: number
+  }
+  entriesWithPaperIds: [number, string][]
+}
+
+export interface UserLibrary {
+  userId: number,
+  paperIds: string[]
+}
+
+export interface CachedUserLibrary {
+  userLibrary: UserLibrary,
+  expires: number
+}

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -75,11 +75,5 @@ export interface UserInfo {
 }
 
 export interface UserLibrary {
-  userId: number,
   paperIds: string[]
-}
-
-export interface CachedUserLibrary {
-  userLibrary: UserLibrary,
-  expires: number
 }


### PR DESCRIPTION
The review adds functionality and api calls to S2 to fetch and modify library entries.

When signed in on S2:
* Fetches the user library entries from S2 and saves them in local storage for an hour
* Shows "In Your Library" or "Save To Library" depending on if its in your library already
* Clicking on "Save To Library" changes the button text and sends a request to add the entry to the user's library
* Clicking on "In Your Library" opens a new tab directed to the user's library in S2

When signed out:
* Clicking on the "Save To Library" button does what it does now, pops open an info box saying it isn't implemented yet. This is because we don't support sign ins from the reader at this time


![readersave (2)](https://user-images.githubusercontent.com/47118133/73486870-c89be900-435a-11ea-8c8d-d9bc67b7f5af.gif)

This is what the reader link looks like on the S2 side for more context:
![signin redirect](https://user-images.githubusercontent.com/47118133/73486970-f2551000-435a-11ea-859e-c739f2357792.gif)

