### PR TITLE
Move PDF on Drawer Open

### DIFF
--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -16,46 +16,11 @@ export class Drawer extends React.PureComponent {
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 
-  getNeedMoveLeft() {
-    const symbol = this.context.selectedSymbol;
-    let l = 0;
-    let t = 0;
-    if (symbol) {
-      const bb = symbol.bounding_boxes[0];
-      const { left, top } = selectors.divDimensionStyles(
-        this.context.pages[bb.page + 1].view,
-        bb,
-      );
-      l = left;
-      t = top;
-    }
-    
-    if (this.context.selectedAnnotationId) {
-      let [,id] = this.context.selectedAnnotationId.split('-');
-      if (id === `${this.context.selectedSymbol?.id}`) {
-        console.log('we gone scroll');
-        return [l, t];
-      } else if (id === `${this.context.selectedCitation?.id}`) {
-        return [10, 20];
-      }
-    }
-
-    // 
-    return [10, 20];
-  }
-
   addChildClass(pdfViewerContainer: HTMLElement) {
     // Creating padding for scroll
     Array.from(pdfViewerContainer.children).forEach(page => {
       page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)  
     })
-
-    // Scroll the Annotation into View
-    // const [l, t] = this.getNeedMoveLeft();
-    // pdfViewerContainer.parentElement?.scroll(
-    //   l, t
-    // );
-    console.log(pdfViewerContainer.parentElement?.clientWidth);
   } 
 
   removeChildClass(pdfViewerContainer: HTMLElement) {

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -15,10 +15,22 @@ export class Drawer extends React.PureComponent {
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 
+  addChildClass(pdfViewerContainer: HTMLElement) {
+    Array.from(pdfViewerContainer.children).forEach(page => {
+      page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)
+    })
+  } 
+
+  removeChildClass(pdfViewerContainer: HTMLElement) {
+    Array.from(pdfViewerContainer.children).forEach(page => {
+      page.classList.remove(PDF_VIEWER_DRAWER_OPEN_CLASS)
+    })
+  }
+
   componentWillUnmount() {
     const { pdfViewer } = this.context;
-    if (pdfViewer != null) {
-      pdfViewer.container.classList.remove(PDF_VIEWER_DRAWER_OPEN_CLASS);
+    if (pdfViewer !== undefined && pdfViewer !== null) {
+      this.removeChildClass(pdfViewer.viewer);
     }
   }
 
@@ -74,9 +86,9 @@ export class Drawer extends React.PureComponent {
     const drawerState = this.drawerState();
     if (pdfViewer != null) {
       if (drawerState !== "closed") {
-        pdfViewer.container.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS);
+        this.addChildClass(pdfViewer.viewer);
       } else {
-        pdfViewer.container.classList.remove(PDF_VIEWER_DRAWER_OPEN_CLASS);
+        this.removeChildClass(pdfViewer.viewer);
       }
     }
 

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -20,6 +20,10 @@ export class Drawer extends React.PureComponent {
     Array.from(pdfViewerContainer.children).forEach(page => {
       page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)  
     })
+
+    if (this.drawerState() === "show-symbols") {
+      this.context.scrollSymbolIntoView();
+    }
   } 
 
   removeChildClass(pdfViewerContainer: HTMLElement) {

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -18,6 +18,8 @@ export class Drawer extends React.PureComponent {
   positionPdfForDrawerOpen(pdfViewerContainer: HTMLElement) {
     // Creating padding for scroll
     Array.from(pdfViewerContainer.children).forEach(page => {
+      // XXX(@zkirby, @andrewhead) per our discussion at https://github.com/allenai/scholar-reader/pull/38/files#r388514946 
+      // this is 'safe' as pages are not deleted when scrolled out of view (just their inner content).
       page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)  
     })
 

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -34,8 +34,8 @@ export class Drawer extends React.PureComponent {
 
   componentWillUnmount() {
     const { pdfViewer } = this.context;
-    if (pdfViewer !== undefined && pdfViewer !== null) {
-      this.removeChildClass(pdfViewer.viewer);
+    if (pdfViewer !== null) {
+      this.removeChildClass(pdfViewer.container);
     }
   }
 
@@ -91,9 +91,9 @@ export class Drawer extends React.PureComponent {
     const drawerState = this.drawerState();
     if (pdfViewer != null) {
       if (drawerState !== "closed") {
-        this.addChildClass(pdfViewer.viewer);
+        this.addChildClass(pdfViewer.container);
       } else {
-        this.removeChildClass(pdfViewer.viewer);
+        this.removeChildClass(pdfViewer.container);
       }
     }
 

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -7,6 +7,7 @@ import { Favorites } from "./Favorites";
 import FeedbackButton from "./FeedbackButton";
 import PaperList from "./PaperList";
 import SearchResults from "./SearchResults";
+import * as selectors from "./selectors";
 import { ScholarReaderContext } from "./state";
 
 const PDF_VIEWER_DRAWER_OPEN_CLASS = "drawer-open";
@@ -15,10 +16,46 @@ export class Drawer extends React.PureComponent {
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 
+  getNeedMoveLeft() {
+    const symbol = this.context.selectedSymbol;
+    let l = 0;
+    let t = 0;
+    if (symbol) {
+      const bb = symbol.bounding_boxes[0];
+      const { left, top } = selectors.divDimensionStyles(
+        this.context.pages[bb.page + 1].view,
+        bb,
+      );
+      l = left;
+      t = top;
+    }
+    
+    if (this.context.selectedAnnotationId) {
+      let [,id] = this.context.selectedAnnotationId.split('-');
+      if (id === `${this.context.selectedSymbol?.id}`) {
+        console.log('we gone scroll');
+        return [l, t];
+      } else if (id === `${this.context.selectedCitation?.id}`) {
+        return [10, 20];
+      }
+    }
+
+    // 
+    return [10, 20];
+  }
+
   addChildClass(pdfViewerContainer: HTMLElement) {
+    // Creating padding for scroll
     Array.from(pdfViewerContainer.children).forEach(page => {
-      page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)
+      page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)  
     })
+
+    // Scroll the Annotation into View
+    // const [l, t] = this.getNeedMoveLeft();
+    // pdfViewerContainer.parentElement?.scroll(
+    //   l, t
+    // );
+    console.log(pdfViewerContainer.parentElement?.clientWidth);
   } 
 
   removeChildClass(pdfViewerContainer: HTMLElement) {

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -7,7 +7,6 @@ import { Favorites } from "./Favorites";
 import FeedbackButton from "./FeedbackButton";
 import PaperList from "./PaperList";
 import SearchResults from "./SearchResults";
-import * as selectors from "./selectors";
 import { ScholarReaderContext } from "./state";
 
 const PDF_VIEWER_DRAWER_OPEN_CLASS = "drawer-open";

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -15,18 +15,18 @@ export class Drawer extends React.PureComponent {
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
 
-  addChildClass(pdfViewerContainer: HTMLElement) {
+  positionPdfForDrawerOpen(pdfViewerContainer: HTMLElement) {
     // Creating padding for scroll
     Array.from(pdfViewerContainer.children).forEach(page => {
       page.classList.add(PDF_VIEWER_DRAWER_OPEN_CLASS)  
     })
 
     if (this.drawerState() === "show-symbols") {
-      this.context.scrollSymbolIntoView();
+      this.context.scrollSymbolHorizontallyIntoView();
     }
   } 
 
-  removeChildClass(pdfViewerContainer: HTMLElement) {
+  removePdfPositioningForDrawerOpen(pdfViewerContainer: HTMLElement) {
     Array.from(pdfViewerContainer.children).forEach(page => {
       page.classList.remove(PDF_VIEWER_DRAWER_OPEN_CLASS)
     })
@@ -35,7 +35,7 @@ export class Drawer extends React.PureComponent {
   componentWillUnmount() {
     const { pdfViewer } = this.context;
     if (pdfViewer != null) {
-      this.removeChildClass(pdfViewer.viewer);
+      this.removePdfPositioningForDrawerOpen(pdfViewer.viewer);
     }
   }
 
@@ -91,9 +91,9 @@ export class Drawer extends React.PureComponent {
     const drawerState = this.drawerState();
     if (pdfViewer != null) {
       if (drawerState !== "closed") {
-        this.addChildClass(pdfViewer.viewer);
+        this.positionPdfForDrawerOpen(pdfViewer.viewer);
       } else {
-        this.removeChildClass(pdfViewer.viewer);
+        this.removePdfPositioningForDrawerOpen(pdfViewer.viewer);
       }
     }
 

--- a/ui/src/Drawer.tsx
+++ b/ui/src/Drawer.tsx
@@ -34,8 +34,8 @@ export class Drawer extends React.PureComponent {
 
   componentWillUnmount() {
     const { pdfViewer } = this.context;
-    if (pdfViewer !== null) {
-      this.removeChildClass(pdfViewer.container);
+    if (pdfViewer != null) {
+      this.removeChildClass(pdfViewer.viewer);
     }
   }
 
@@ -91,9 +91,9 @@ export class Drawer extends React.PureComponent {
     const drawerState = this.drawerState();
     if (pdfViewer != null) {
       if (drawerState !== "closed") {
-        this.addChildClass(pdfViewer.container);
+        this.addChildClass(pdfViewer.viewer);
       } else {
-        this.removeChildClass(pdfViewer.container);
+        this.removeChildClass(pdfViewer.viewer);
       }
     }
 

--- a/ui/src/PageOverlay.tsx
+++ b/ui/src/PageOverlay.tsx
@@ -52,6 +52,7 @@ class PageOverlay extends React.PureComponent<PageProps, {}> {
     ) {
       this.props.view.div.removeChild(this._element);
     }
+    this.props.view.div.classList.remove("scholar-reader-overlay-2");
   }
 
   onSelectionMade(anchor: Point, active: Point) {

--- a/ui/src/PageOverlay.tsx
+++ b/ui/src/PageOverlay.tsx
@@ -52,7 +52,6 @@ class PageOverlay extends React.PureComponent<PageProps, {}> {
     ) {
       this.props.view.div.removeChild(this._element);
     }
-    this.props.view.div.classList.remove("scholar-reader-overlay-2");
   }
 
   onSelectionMade(anchor: Point, active: Point) {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -404,10 +404,30 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
           undefined,
           { name: "XYZ" },
           box.left + SCROLL_OFFSET_X,
-          box.top + SCROLL_OFFSET_Y
+          box.top + SCROLL_OFFSET_Y,
+          null,
         ]
       });
     }
+  }
+
+  scrollSymbolIntoView() {
+    setTimeout(() => {
+      const { selectedSymbol, pdfViewer, pages } = this.state;
+      if (pdfViewer && selectedSymbol) {
+        const symBounds = selectedSymbol.bounding_boxes[0];
+        const { left } = selectors.divDimensionStyles(
+          pages[symBounds.page + 1].view, symBounds
+        );
+        let viewPortWidth = pages[symBounds.page + 1].view.viewport.width;
+        viewPortWidth = (viewPortWidth - viewPortWidth/3);
+        console.log(viewPortWidth, left);
+        // Obscures the last 1/3 of the viewport 
+        if (left > viewPortWidth) {
+          pdfViewer.container.scrollLeft += viewPortWidth;
+        }
+      } 
+    }, 10);
   }
 
   render() {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -420,11 +420,14 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
           pages[symBounds.page + 1].view, symBounds
         );
         let viewPortWidth = pages[symBounds.page + 1].view.viewport.width;
-        viewPortWidth = (viewPortWidth - viewPortWidth/3);
-        console.log(viewPortWidth, left);
+        
+        console.log("VIEWPORT")
+        console.log(`show if ${left} > ${viewPortWidth - viewPortWidth/3} given vp is ${viewPortWidth} and it's already scrolled ${pdfViewer.container.scrollLeft} and with a window width of ${window.innerWidth}`);
+
+        viewPortWidth = (viewPortWidth - viewPortWidth/4);
         // Obscures the last 1/3 of the viewport 
         if (left > viewPortWidth) {
-          pdfViewer.container.scrollLeft += viewPortWidth;
+          //pdfViewer.container.scrollLeft += viewPortWidth;
         }
       } 
     }, 10);

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -421,7 +421,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
     const SYMBOL_VIEW_PADDING = 50;
     if (pdfViewer && selectedSymbol) {
       const symBounds = selectedSymbol.bounding_boxes[0];
-      const { x } = pdfViewer.container.getBoundingClientRect() as DOMRect;
+      const pdfLeft = (pdfViewer.container.getBoundingClientRect() as DOMRect).x;
       if (pages[symBounds.page + 1].view != null) {
         const { left, width } = selectors.divDimensionStyles(
           pages[symBounds.page + 1].view, symBounds
@@ -430,12 +430,12 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         * Each component of the calculation: 
         * left + width = right position on the pdf page of the selected symbol
         * scrollLeft = how much the pdf has been scrolled left already
-        * x = how far to the left the pdf is relative to the viewport
+        * pdfLeft = how far to the left the pdf is relative to the viewport
         * ----------------
         * innerWidth = possible visible area of the viewport for the entire website
         * 470 = width of the drawer that is now obscuring the view
         */
-        const relativeSymbolRightPosition = (left + width) - pdfViewer.container.scrollLeft + x;
+        const relativeSymbolRightPosition = (left + width) - pdfViewer.container.scrollLeft + pdfLeft;
         const viewableViewportWidth = window.innerWidth - DRAWER_WIDTH;
         if (relativeSymbolRightPosition > viewableViewportWidth) {
           // Add 50px padding to make the symbol close to the drawer but not hidden by it.

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -73,7 +73,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
       setJumpPaperId: this.setJumpPaperId.bind(this),
       selectedSymbol: null,
       setSelectedSymbol: this.setSelectedSymbol.bind(this),
-      scrollSymbolIntoView: this.scrollSymbolIntoView.bind(this),
+      scrollSymbolHorizontallyIntoView: this.scrollSymbolHorizontallyIntoView.bind(this),
       selectedCitation: null,
       setSelectedCitation: this.setSelectedCitation.bind(this),
       jumpSymbol: null,
@@ -410,17 +410,23 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
           { name: "XYZ" },
           box.left + SCROLL_OFFSET_X,
           box.top + SCROLL_OFFSET_Y,
-          null,
         ]
       });
     }
   }
 
-  scrollSymbolIntoView() {
+  /**
+   * Will scroll a symbol horizontally into view when the drawer opens
+   * if it is now obscured by the drawer.
+   */
+  scrollSymbolHorizontallyIntoView() {
     const { selectedSymbol, pdfViewer, pages, pdfSideBarIsOpen } = this.state;
     const PDF_SIDE_PANEL_WIDTH = 200;
+    const DRAWER_WIDTH = 470;
+    const SYMBOL_VIEW_PADDING = 50;
     if (pdfViewer && selectedSymbol) {
       const symBounds = selectedSymbol.bounding_boxes[0];
+      console.log("STYLE ", pdfViewer.container.getBoundingClientRect())
       if (pages[symBounds.page + 1].view != null) {
         const { left, width } = selectors.divDimensionStyles(
           pages[symBounds.page + 1].view, symBounds
@@ -435,10 +441,10 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         * 470 = width of the drawer that is now obscuring the view
         */
         const relativeSymbolRightPosition = (left + width) - pdfViewer.container.scrollLeft + (pdfSideBarIsOpen ? PDF_SIDE_PANEL_WIDTH : 0);
-        const viewableViewportWidth = window.innerWidth - 470;
+        const viewableViewportWidth = window.innerWidth - DRAWER_WIDTH;
         if (relativeSymbolRightPosition > viewableViewportWidth) {
           // Add 50px padding to make the symbol close to the drawer but not hidden by it.
-          pdfViewer.container.scrollLeft += Math.max((relativeSymbolRightPosition - viewableViewportWidth) + 50, 0);
+          pdfViewer.container.scrollLeft += Math.max((relativeSymbolRightPosition - viewableViewportWidth) + SYMBOL_VIEW_PADDING, 0);
         }
       } 
     }

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -421,7 +421,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
     const PDF_SIDE_PANEL_WIDTH = 200;
     if (pdfViewer && selectedSymbol) {
       const symBounds = selectedSymbol.bounding_boxes[0];
-      if (pages[symBounds.page + 1].view) {
+      if (pages[symBounds.page + 1].view != null) {
         const { left, width } = selectors.divDimensionStyles(
           pages[symBounds.page + 1].view, symBounds
         );
@@ -433,9 +433,6 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         * ----------------
         * innerWidth = possible visible area of the viewport for the entire website
         * 470 = width of the drawer that is now obscuring the view
-        */
-        /*
-        * TODO(@zkirby) need to account for if the side panel is not open.
         */
         const relativeSymbolRightPosition = (left + width) - pdfViewer.container.scrollLeft + (pdfSideBarIsOpen ? PDF_SIDE_PANEL_WIDTH : 0);
         const viewableViewportWidth = window.innerWidth - 470;

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -66,7 +66,6 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
       setPages: this.setPages.bind(this),
       pdfDocument: null,
       pdfViewer: null,
-      pdfSideBarIsOpen: null,
       favorites: {},
       toggleFavorite: this.toggleFavorite.bind(this),
       jumpPaperId: null,
@@ -310,9 +309,6 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
     eventBus.on("documentloaded", (eventData: DocumentLoadedEvent) => {
       this.setState({ pdfDocument: eventData.source });
     });
-    eventBus.on("sidebarviewchanged", ({source: { isOpen }}) => {
-      this.setState({ pdfSideBarIsOpen: isOpen })
-    })
 
     /*
      * TODO(andrewhead): Do we need to add pages that are *already loaded* at initialization time
@@ -420,13 +416,12 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
    * if it is now obscured by the drawer.
    */
   scrollSymbolHorizontallyIntoView() {
-    const { selectedSymbol, pdfViewer, pages, pdfSideBarIsOpen } = this.state;
-    const PDF_SIDE_PANEL_WIDTH = 200;
+    const { selectedSymbol, pdfViewer, pages } = this.state;
     const DRAWER_WIDTH = 470;
     const SYMBOL_VIEW_PADDING = 50;
     if (pdfViewer && selectedSymbol) {
       const symBounds = selectedSymbol.bounding_boxes[0];
-      console.log("STYLE ", pdfViewer.container.getBoundingClientRect())
+      const { x } = pdfViewer.container.getBoundingClientRect() as DOMRect;
       if (pages[symBounds.page + 1].view != null) {
         const { left, width } = selectors.divDimensionStyles(
           pages[symBounds.page + 1].view, symBounds
@@ -435,12 +430,12 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         * Each component of the calculation: 
         * left + width = right position on the pdf page of the selected symbol
         * scrollLeft = how much the pdf has been scrolled left already
-        * PDF_SIDE_PANEL_WIDTH = the extra padding from the pdf's side panel (hard coded in pdf.js code)
+        * x = how far to the left the pdf is relative to the viewport
         * ----------------
         * innerWidth = possible visible area of the viewport for the entire website
         * 470 = width of the drawer that is now obscuring the view
         */
-        const relativeSymbolRightPosition = (left + width) - pdfViewer.container.scrollLeft + (pdfSideBarIsOpen ? PDF_SIDE_PANEL_WIDTH : 0);
+        const relativeSymbolRightPosition = (left + width) - pdfViewer.container.scrollLeft + x;
         const viewableViewportWidth = window.innerWidth - DRAWER_WIDTH;
         if (relativeSymbolRightPosition > viewableViewportWidth) {
           // Add 50px padding to make the symbol close to the drawer but not hidden by it.

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -419,18 +419,21 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         const { left } = selectors.divDimensionStyles(
           pages[symBounds.page + 1].view, symBounds
         );
-        let viewPortWidth = pages[symBounds.page + 1].view.viewport.width;
         
-        console.log("VIEWPORT")
-        console.log(`show if ${left} > ${viewPortWidth - viewPortWidth/3} given vp is ${viewPortWidth} and it's already scrolled ${pdfViewer.container.scrollLeft} and with a window width of ${window.innerWidth}`);
-
-        viewPortWidth = (viewPortWidth - viewPortWidth/4);
-        // Obscures the last 1/3 of the viewport 
-        if (left > viewPortWidth) {
-          //pdfViewer.container.scrollLeft += viewPortWidth;
+        // Left = left position on the pdf page, scroll left = left offset of the pdf
+        // 200 = extra padding from the pdf side panel. 
+        const relativeSymbolLeftPosition = left - pdfViewer.container.scrollLeft + 200;
+        // window.innerWidth = possible visible area of the viewport, 
+        // 470 = width now obscured by the open drawer. 
+        const viewableViewportWidth = window.innerWidth - 470;
+        console.log(`Left Position: ${relativeSymbolLeftPosition} > ${viewableViewportWidth} | moving: ${relativeSymbolLeftPosition - viewableViewportWidth}`);
+        if (relativeSymbolLeftPosition > viewableViewportWidth) {
+          // Here we are moving the pdf to the left by the amount the symbol was obscured by
+          // + some padding to make it a little bit away from the drawer. 
+          pdfViewer.container.scrollLeft += Math.max((relativeSymbolLeftPosition - viewableViewportWidth) + 50, 0);
         }
       } 
-    }, 10);
+    }, 0);
   }
 
   render() {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -72,6 +72,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
       setJumpPaperId: this.setJumpPaperId.bind(this),
       selectedSymbol: null,
       setSelectedSymbol: this.setSelectedSymbol.bind(this),
+      scrollSymbolIntoView: this.scrollSymbolIntoView.bind(this),
       selectedCitation: null,
       setSelectedCitation: this.setSelectedCitation.bind(this),
       jumpSymbol: null,
@@ -412,28 +413,31 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
   }
 
   scrollSymbolIntoView() {
-    setTimeout(() => {
-      const { selectedSymbol, pdfViewer, pages } = this.state;
-      if (pdfViewer && selectedSymbol) {
-        const symBounds = selectedSymbol.bounding_boxes[0];
-        const { left } = selectors.divDimensionStyles(
-          pages[symBounds.page + 1].view, symBounds
-        );
-        
-        // Left = left position on the pdf page, scroll left = left offset of the pdf
-        // 200 = extra padding from the pdf side panel. 
-        const relativeSymbolLeftPosition = left - pdfViewer.container.scrollLeft + 200;
-        // window.innerWidth = possible visible area of the viewport, 
-        // 470 = width now obscured by the open drawer. 
-        const viewableViewportWidth = window.innerWidth - 470;
-        console.log(`Left Position: ${relativeSymbolLeftPosition} > ${viewableViewportWidth} | moving: ${relativeSymbolLeftPosition - viewableViewportWidth}`);
-        if (relativeSymbolLeftPosition > viewableViewportWidth) {
-          // Here we are moving the pdf to the left by the amount the symbol was obscured by
-          // + some padding to make it a little bit away from the drawer. 
-          pdfViewer.container.scrollLeft += Math.max((relativeSymbolLeftPosition - viewableViewportWidth) + 50, 0);
-        }
-      } 
-    }, 0);
+    const { selectedSymbol, pdfViewer, pages } = this.state;
+    if (pdfViewer && selectedSymbol) {
+      const symBounds = selectedSymbol.bounding_boxes[0];
+      const { left } = selectors.divDimensionStyles(
+        pages[symBounds.page + 1].view, symBounds
+      );
+      /*
+      * Each component of the calculation: 
+      * Left = left position on the pdf page of the selected symbol
+      * scrollLeft = how much the pdf has been scrolled left already
+      * 200 = the extra padding from the pdf's side panel
+      * ----------------
+      * innerWidth = possible visible area of the viewport
+      * 470 = width of the drawer that is now obscuring the view
+      */
+      /*
+      * TODO(@zkirby) need to account for if the side panel is not open.
+      */
+      const relativeSymbolLeftPosition = left - pdfViewer.container.scrollLeft + 200;
+      const viewableViewportWidth = window.innerWidth - 470;
+      if (relativeSymbolLeftPosition > viewableViewportWidth) {
+        // Add 50px padding to make the symbol close to the drawer but not hidden by it.
+        pdfViewer.container.scrollLeft += Math.max((relativeSymbolLeftPosition - viewableViewportWidth) + 50, 0);
+      }
+    } 
   }
 
   render() {

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -52,7 +52,7 @@ export interface State {
   setJumpPaperId(s2Id: string | null): void;
   selectedSymbol: Symbol | null;
   setSelectedSymbol(symbol: Symbol | null): void;
-  scrollSymbolIntoView(): void;
+  scrollSymbolHorizontallyIntoView(): void;
   selectedCitation: Citation | null;
   setSelectedCitation(citation: Citation | null): void;
   jumpSymbol: Symbol | null;
@@ -121,7 +121,7 @@ const defaultState: State = {
   setJumpPaperId: () => {},
   selectedSymbol: null,
   setSelectedSymbol: () => {},
-  scrollSymbolIntoView: () => {},
+  scrollSymbolHorizontallyIntoView: () => {},
   selectedCitation: null,
   setSelectedCitation: () => {},
   jumpSymbol: null,

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -41,6 +41,7 @@ export interface State {
   setPages(pages: Pages): void;
   pdfDocument: PDFDocumentProxy | null;
   pdfViewer: PDFViewer | null;
+  pdfSideBarIsOpen: boolean | null;
 
   /*
    * USER INTERFACE STATE
@@ -113,6 +114,7 @@ const defaultState: State = {
   setPages: () => {},
   pdfDocument: null,
   pdfViewer: null,
+  pdfSideBarIsOpen: null,
   favorites: {},
   toggleFavorite: () => {},
   jumpPaperId: null,

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -41,7 +41,6 @@ export interface State {
   setPages(pages: Pages): void;
   pdfDocument: PDFDocumentProxy | null;
   pdfViewer: PDFViewer | null;
-  pdfSideBarIsOpen: boolean | null;
 
   /*
    * USER INTERFACE STATE
@@ -114,7 +113,6 @@ const defaultState: State = {
   setPages: () => {},
   pdfDocument: null,
   pdfViewer: null,
-  pdfSideBarIsOpen: null,
   favorites: {},
   toggleFavorite: () => {},
   jumpPaperId: null,

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -51,6 +51,7 @@ export interface State {
   setJumpPaperId(s2Id: string | null): void;
   selectedSymbol: Symbol | null;
   setSelectedSymbol(symbol: Symbol | null): void;
+  scrollSymbolIntoView(): void;
   selectedCitation: Citation | null;
   setSelectedCitation(citation: Citation | null): void;
   jumpSymbol: Symbol | null;
@@ -118,6 +119,7 @@ const defaultState: State = {
   setJumpPaperId: () => {},
   selectedSymbol: null,
   setSelectedSymbol: () => {},
+  scrollSymbolIntoView: () => {},
   selectedCitation: null,
   setSelectedCitation: () => {},
   jumpSymbol: null,

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -7,6 +7,9 @@
 
   &.drawer-open {
     padding-right: @drawer-paper-clipping-width + @margin * 4;
+    // A very unfortunate side effect of using padding is that it 
+    // will distort the border image if the user shrinks the page too much.
+    border-image: none;
   }
 }
 

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -2,11 +2,11 @@
  * Move view of PDF page inward when the drawer is open.
  * TODO(andrewhead): Find a way to animate drawer even when left sidebar is open.
  */
-#viewerContainer {
+.page {
   transition-property: "padding-right";
 
   &.drawer-open {
-    padding-right: @drawer-paper-clipping-width + @margin * 2;
+    padding-right: @drawer-paper-clipping-width + @margin * 4;
   }
 }
 

--- a/ui/src/types/pdfjs-viewer.ts
+++ b/ui/src/types/pdfjs-viewer.ts
@@ -38,7 +38,6 @@ export interface DocumentLoadedEvent {
 export interface PDFViewer {
   scrollPageIntoView: (params: ScrollPageIntoViewParameters) => void;
   container: HTMLDivElement;
-  viewer: HTMLDivElement;
 }
 
 interface ScrollPageIntoViewParameters {

--- a/ui/src/types/pdfjs-viewer.ts
+++ b/ui/src/types/pdfjs-viewer.ts
@@ -38,6 +38,7 @@ export interface DocumentLoadedEvent {
 export interface PDFViewer {
   scrollPageIntoView: (params: ScrollPageIntoViewParameters) => void;
   container: HTMLDivElement;
+  viewer: HTMLDivElement;
 }
 
 interface ScrollPageIntoViewParameters {


### PR DESCRIPTION
The PDF now moves to the side on small resolutions and will be horizontally scrollable on large resolutions. 

**edit**: It will now move a symbol into view if it would otherwise have been obscured by the side drawer.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22308211/75739625-3f116b00-5cba-11ea-9570-88599f881d65.gif)