### PR TITLE
Changing matching symbol entity highlight to faint blue

### DIFF
--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -36,7 +36,7 @@
   &.matching-symbol-annotation,
   &.selected,
   &.annotation-selected {
-    border-bottom: @underline-width+1px @highlight-annotation-color solid;
+    background-color: @highlight-matching-entity-color;
   }
 }
 

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -33,7 +33,7 @@
 @highlight-border-color: #88f;
 @highlight-hover-opacity: 0.2;
 @highlight-hitbox-padding: .1em;
-@highlight-annotation-color: @s2-influential-citation-orange;
+@highlight-matching-entity-color: rgba(70, 130, 180, 0.3);
 /**
  * TEXT STYLING
  */


### PR DESCRIPTION
Description: Matching selected symbol entity now has a faint blue highlight instead of an orange underline. I didn't use hex color because hex code doesn't support transparency, I opted for RGBA color here as the variable highlight-color is using couple lines above, but it is also worth noting that there's another version of the hex color that supports alpha channel with the format AARRGGBB (which makes the hex color code 8 characters long though). 

Screenshot: 
![faint blue background](https://user-images.githubusercontent.com/52334652/75018581-1381bb80-5444-11ea-8e21-610380518ebc.png)
