### PR TITLE
Consistent highlight between pdf.js annotation and custom annotation

### DIFF
--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -27,7 +27,8 @@
   &:hover,
   &.selected,
   &.annotation-selected {
-    background-color: @highlight-color;
+    background: @highlight-hover-background;
+    opacity: @highlight-hover-opacity;
     cursor: pointer;
   }
   /**

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -22,7 +22,7 @@
   * and custom purple highlight for citation annotations.
   */
 .linkAnnotation a:not([href^="#cite"]):hover {
-  background: rgb(0, 0, 255);
-  opacity: 0.2;
-  box-shadow: 0px 2px 10px rgb(0, 0, 255)
+  background: @highlight-hover-background;
+  opacity: @highlight-hover-opacity;
+  box-shadow: 0px 2px 10px @highlight-hover-background;
 }

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -17,12 +17,17 @@
   display: none;
 }
 
-/** 
-  * Consistent highlight between default pdf.js highlight for tables, figures, etc. 
+/**
+  * Consistent default behavior between pdf.js highlight for tables, figures, etc.
   * and custom purple highlight for citation annotations.
   */
-.annotationLayer .linkAnnotation > a:hover {
-  background: @highlight-hover-background;
-  opacity: @highlight-hover-opacity;
-  box-shadow: 0px 2px 10px @highlight-hover-background;
+.annotationLayer .linkAnnotation > a {
+  border-bottom: @underline-width @underline-color dotted;
+
+  &:hover, 
+  &.selected {
+    background: @highlight-hover-background;
+    opacity: @highlight-hover-opacity;
+    box-shadow: 0px 2px 10px @highlight-hover-background;
+  }
 }

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -16,3 +16,13 @@
 .linkAnnotation a[href^="#cite"] {
   display: none;
 }
+
+/** 
+  * Consistent highlight between default pdf.js highlight for tables, figures, etc. 
+  * and custom purple highlight for citation annotations.
+  */
+.linkAnnotation a:not([href^="#cite"]):hover {
+  background: rgb(0, 0, 255);
+  opacity: 0.2;
+  box-shadow: 0px 2px 10px rgb(0, 0, 255)
+}

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -21,8 +21,7 @@
   * Consistent highlight between default pdf.js highlight for tables, figures, etc. 
   * and custom purple highlight for citation annotations.
   */
-.annotationLayer .linkAnnotation > a:hover,
-.annotationLayer .buttonWidgetAnnotation.pushBotton > a:hover {
+.annotationLayer .linkAnnotation > a:hover {
   background: @highlight-hover-background;
   opacity: @highlight-hover-opacity;
   box-shadow: 0px 2px 10px @highlight-hover-background;

--- a/ui/src/style/pdf-viewer.less
+++ b/ui/src/style/pdf-viewer.less
@@ -21,7 +21,8 @@
   * Consistent highlight between default pdf.js highlight for tables, figures, etc. 
   * and custom purple highlight for citation annotations.
   */
-.linkAnnotation a:not([href^="#cite"]):hover {
+.annotationLayer .linkAnnotation > a:hover,
+.annotationLayer .buttonWidgetAnnotation.pushBotton > a:hover {
   background: @highlight-hover-background;
   opacity: @highlight-hover-opacity;
   box-shadow: 0px 2px 10px @highlight-hover-background;

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -32,6 +32,7 @@
 @highlight-color: rgba(0, 0, 255, 0.2);
 @highlight-border-color: #88f;
 @highlight-hover-opacity: 0.2;
+@highlight-hover-background: rgb(0, 0, 255);
 @highlight-hitbox-padding: .1em;
 @highlight-matching-entity-color: rgba(70, 130, 180, 0.3);
 /**


### PR DESCRIPTION
I used the :not() selector because we previously disabled behavior for any links with "#cite", this is just to avoid any unexpected behavior. 

All modified properties were found in the original pdf.js stylesheet, I only changed the properties that have to do with colors. 

Screenshots:
![10](https://user-images.githubusercontent.com/52334652/76137806-d990e780-5ff5-11ea-8d66-4eb91fd456db.png)
![11](https://user-images.githubusercontent.com/52334652/76137809-dc8bd800-5ff5-11ea-890d-3ecf85cd8d5f.png)
![12](https://user-images.githubusercontent.com/52334652/76137811-e01f5f00-5ff5-11ea-9aa5-cedd3a1c17ce.png)
(to be compared with our custom highlights)
![13](https://user-images.githubusercontent.com/52334652/76137819-0b09b300-5ff6-11ea-8b2d-2734af88f249.png)
