### PR TITLE
Merge Consecutive <mi> Tags

### DIFF
--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -51,9 +51,11 @@ def get_characters(mathml: str) -> List[Character]:
 def get_symbols(mathml: str) -> List[Symbol]:
     soup = BeautifulSoup(mathml, "lxml")
     node_symbols = []
-    consecutive_chars: List[Symbol] = []
-    all_indices: List[int] = []
-    for symbol_node in soup.find_all_next(SYMBOL_TAGS):
+    consecutive_char_sequence: List[BeautifulSoup] = [] # The symbol_nodes of consecutive characters
+    consecutive_char_indices: List[int] = [] # Indices of the characters of a consecutive character sequence
+    # It's 'safe' to call soup.find_all as the underlying bs4 implementation 
+    # appears to preserve order https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/bs4/element.py
+    for symbol_node in soup.find_all(SYMBOL_TAGS):
 
         # Collect indexes of all characters that belong to this symbol
         characters = []
@@ -69,18 +71,20 @@ def get_symbols(mathml: str) -> List[Symbol]:
         # Group consecutive character symbols only if they are a child of the mrow tag.
         # The .has_attr('s2:end') is necessary as not every symbol is annotated by katex
         if symbol_node.has_attr('s2:end') and symbol_node.parent.name in MERGABLE_PARENT_TAGS and symbol_node.name in CHARACTER_TAGS:
-            if len(consecutive_chars) > 0 and not consecutive_chars[-1]['s2:end'] == symbol_node['s2:start']:
-                node_symbols.append(_merge_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
-                consecutive_chars = []
-                all_indices = []
-            consecutive_chars.append(symbol_node)
-            all_indices.extend(characters)
-        elif len(consecutive_chars) > 0:
-            node_symbols.append(_merge_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
-            consecutive_chars = []
-            all_indices = []
-
-        if len(consecutive_chars) == 0:
+            # This symbol_node is part of consecutive_char_sequence but not the current sequence.
+            if len(consecutive_char_sequence) > 0 and not consecutive_char_sequence[-1]['s2:end'] == symbol_node['s2:start']:
+                new_symbol = _merge_consecutive_symbols(consecutive_char_sequence, consecutive_char_indices, soup.new_tag(symbol_node.name))
+                node_symbols.append(new_symbol)
+                consecutive_char_sequence = []
+                consecutive_char_indices = []
+            consecutive_char_sequence.append(symbol_node)
+            consecutive_char_indices.extend(characters)
+        else:
+            if len(consecutive_char_sequence) > 0:
+                new_symbol = _merge_consecutive_symbols(consecutive_char_sequence, consecutive_char_indices, soup.new_tag(symbol_node.name))
+                node_symbols.append(new_symbol)
+                consecutive_char_sequence = []
+                consecutive_char_indices = []
             # Clean the MathML of our annotations. Do this cleaning on a clone of the node, so that the
             # annotations are available for processing later nodes.
             node_clone = _clean_node_of_annotations(symbol_node)
@@ -91,29 +95,29 @@ def get_symbols(mathml: str) -> List[Symbol]:
             )
 
     # Possibility that the last symbol was part of a continuing symbol
-    if len(consecutive_chars) > 0:
-        node_symbols.append(_merge_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
+    if len(consecutive_char_sequence) > 0:
+        node_symbols.append(_merge_consecutive_symbols(consecutive_char_sequence, consecutive_char_indices, soup.new_tag(consecutive_char_sequence[0].name)))
 
     # Set the children of each symbols to descendant symbols beneath it in the tree.
     symbols = _set_children(node_symbols)
     return symbols
 
 # Removes s2 annotations from node and all descendants
-def _clean_node_of_annotations(symbol_node: Symbol) -> Symbol:
+def _clean_node_of_annotations(symbol_node: BeautifulSoup) -> BeautifulSoup:
     node_clone = copy.copy(symbol_node)
     _remove_s2_annotations(node_clone)
     for descendant in node_clone.descendants:
         _remove_s2_annotations(descendant)
     return node_clone
 
-# Combines all symbols in consecutive_chars into one NodeSymbol
-def _merge_consecutive_symbols(consecutive_chars: List[Symbol], all_indices: List[int], base_tag: Symbol) -> NodeSymbol:
-    base_tag['s2:start'] = consecutive_chars[0]['s2:start']
-    base_tag['s2:end'] = consecutive_chars[-1]['s2:end']
-    base_tag['s2:index'] = consecutive_chars[0]['s2:index']
-    base_tag.string  = ''.join(list(map(lambda node: node.string, consecutive_chars)))
+# Combines all symbols in consecutive_char_sequence into one NodeSymbol
+def _merge_consecutive_symbols(consecutive_char_sequence: List[BeautifulSoup], consecutive_char_indices: List[int], base_tag: BeautifulSoup) -> NodeSymbol:
+    base_tag['s2:start'] = consecutive_char_sequence[0]['s2:start']
+    base_tag['s2:end'] = consecutive_char_sequence[-1]['s2:end']
+    base_tag['s2:index'] = consecutive_char_sequence[0]['s2:index']
+    base_tag.string = ''.join(list(map(lambda node: node.string, consecutive_char_sequence)))
     node_clone = _clean_node_of_annotations(base_tag)
-    return NodeSymbol(characters=all_indices, mathml=str(node_clone), node=base_tag)
+    return NodeSymbol(characters=consecutive_char_indices, mathml=str(node_clone), node=base_tag)
 
 def _set_children(node_symbols: List[NodeSymbol]) -> List[Symbol]:
 

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -67,7 +67,8 @@ def get_symbols(mathml: str) -> List[Symbol]:
                 characters.append(index)
 
         # Group consecutive character symbols only if they are a child of the mrow tag.
-        if symbol_node.parent.name in VALID_PARENT_TAG and symbol_node.name in CHARACTER_TAGS:
+        # The .has_attr('s2:end') is necessary as not every symbol is annotated by katext
+        if symbol_node.has_attr('s2:end') and symbol_node.parent.name in VALID_PARENT_TAG and symbol_node.name in CHARACTER_TAGS:
             if len(consecutive_chars) > 0 and not consecutive_chars[-1]['s2:end'] == symbol_node['s2:start']:
                 node_symbols.append(_build_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
                 consecutive_chars = []

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -80,11 +80,10 @@ def get_symbols(mathml: str) -> List[Symbol]:
             consecutive_chars = []
             all_indices = []
 
-        # Clean the MathML of our annotations. Do this cleaning on a clone of the node, so that the
-        # annotations are available for processing later nodes.
-        node_clone = _clean_node_of_annotations(symbol_node)
-
         if len(consecutive_chars) == 0:
+            # Clean the MathML of our annotations. Do this cleaning on a clone of the node, so that the
+            # annotations are available for processing later nodes.
+            node_clone = _clean_node_of_annotations(symbol_node)
             node_symbols.append(
                 # set node to 'symbol_node', not clone, as the node must have a parent for the
                 # 'set_children' method. The clone will have had its parent removed.

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -21,7 +21,7 @@ invisible and we wouldn't want to detect it anyway.
 KATEX_ERROR_COLOR = "#ffffff"
 CHARACTER_TAGS = ["mi"]
 SYMBOL_TAGS = ["msubsup", "msub", "msup", "mi"]
-VALID_PARENT_TAG = ["mrow"]
+MERGABLE_PARENT_TAGS = ["mrow"]
 
 def _is_node_annotated(node: Any) -> bool:
     return (
@@ -51,9 +51,9 @@ def get_characters(mathml: str) -> List[Character]:
 def get_symbols(mathml: str) -> List[Symbol]:
     soup = BeautifulSoup(mathml, "lxml")
     node_symbols = []
-    consecutive_chars = []
-    all_indices = []
-    for symbol_node in soup.find_all(SYMBOL_TAGS):
+    consecutive_chars: List[Symbol] = []
+    all_indices: List[int] = []
+    for symbol_node in soup.find_all_next(SYMBOL_TAGS):
 
         # Collect indexes of all characters that belong to this symbol
         characters = []
@@ -68,15 +68,15 @@ def get_symbols(mathml: str) -> List[Symbol]:
 
         # Group consecutive character symbols only if they are a child of the mrow tag.
         # The .has_attr('s2:end') is necessary as not every symbol is annotated by katex
-        if symbol_node.has_attr('s2:end') and symbol_node.parent.name in VALID_PARENT_TAG and symbol_node.name in CHARACTER_TAGS:
+        if symbol_node.has_attr('s2:end') and symbol_node.parent.name in MERGABLE_PARENT_TAGS and symbol_node.name in CHARACTER_TAGS:
             if len(consecutive_chars) > 0 and not consecutive_chars[-1]['s2:end'] == symbol_node['s2:start']:
-                node_symbols.append(_build_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
+                node_symbols.append(_merge_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
                 consecutive_chars = []
                 all_indices = []
             consecutive_chars.append(symbol_node)
             all_indices.extend(characters)
         elif len(consecutive_chars) > 0:
-            node_symbols.append(_build_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
+            node_symbols.append(_merge_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
             consecutive_chars = []
             all_indices = []
 
@@ -92,7 +92,7 @@ def get_symbols(mathml: str) -> List[Symbol]:
 
     # Possibility that the last symbol was part of a continuing symbol
     if len(consecutive_chars) > 0:
-        node_symbols.append(_build_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
+        node_symbols.append(_merge_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
 
     # Set the children of each symbols to descendant symbols beneath it in the tree.
     symbols = _set_children(node_symbols)
@@ -103,14 +103,14 @@ def _clean_node_of_annotations(symbol_node: Symbol) -> Symbol:
     node_clone = copy.copy(symbol_node)
     _remove_s2_annotations(node_clone)
     for descendant in node_clone.descendants:
-         _remove_s2_annotations(descendant)
+        _remove_s2_annotations(descendant)
     return node_clone
 
 # Combines all symbols in consecutive_chars into one NodeSymbol
-def _build_consecutive_symbols(consecutive_chars: List[Symbol], all_indices: List[int], base_tag: Symbol) -> NodeSymbol:
+def _merge_consecutive_symbols(consecutive_chars: List[Symbol], all_indices: List[int], base_tag: Symbol) -> NodeSymbol:
     base_tag['s2:start'] = consecutive_chars[0]['s2:start']
     base_tag['s2:end'] = consecutive_chars[-1]['s2:end']
-    base_tag['s2:index'] = base_tag['s2:start']
+    base_tag['s2:index'] = consecutive_chars[0]['s2:index']
     base_tag.string  = ''.join(list(map(lambda node: node.string, consecutive_chars)))
     node_clone = _clean_node_of_annotations(base_tag)
     return NodeSymbol(characters=all_indices, mathml=str(node_clone), node=base_tag)

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -107,7 +107,7 @@ def _clean_node_of_annotations(symbol_node: Symbol) -> Symbol:
     return node_clone
 
 # Combines all symbols in consecutive_chars into one NodeSymbol
-def _build_consecutive_symbols(consecutive_chars: List[Symbol], all_indices, base_tag: Symbol) -> NodeSymbol:
+def _build_consecutive_symbols(consecutive_chars: List[Symbol], all_indices: List[int], base_tag: Symbol) -> NodeSymbol:
     base_tag['s2:start'] = consecutive_chars[0]['s2:start']
     base_tag['s2:end'] = consecutive_chars[-1]['s2:end']
     base_tag['s2:index'] = base_tag['s2:start']

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -19,7 +19,7 @@ invisible and we wouldn't want to detect it anyway.
 KATEX_ERROR_COLOR = "#ffffff"
 CHARACTER_TAGS = ["mi"]
 SYMBOL_TAGS = ["msubsup", "msub", "msup", "mi"]
-INVALID_PARENT_TAGS = ["msubsup", "msub", "msup", "mfrac"]
+VALID_PARENT_TAG = ["mrow"]
 
 def _is_node_annotated(node: Any) -> bool:
     return (
@@ -64,8 +64,8 @@ def get_symbols(mathml: str) -> List[Symbol]:
             if index is not None:
                 characters.append(index)
 
-        # Group Consecutive Character Symbols
-        if symbol_node.parent.name not in INVALID_PARENT_TAGS and symbol_node.name in CHARACTER_TAGS:
+        # Group consecutive character symbols only if they are a child of the mrow tag.
+        if symbol_node.parent.name in VALID_PARENT_TAG and symbol_node.name in CHARACTER_TAGS:
             if len(consecutive_chars) > 0 and not consecutive_chars[-1]['s2:end'] == symbol_node['s2:start']:
                 node_symbols.append(_build_consecutive_symbols(consecutive_chars, all_indices, soup.new_tag('mi')))
                 consecutive_chars = []

--- a/data-processing/common/parse_equation.py
+++ b/data-processing/common/parse_equation.py
@@ -6,10 +6,12 @@ from bs4 import BeautifulSoup
 
 from common.types import Character, CharacterIndex, Symbol
 
+
 class NodeSymbol(NamedTuple):
     node: BeautifulSoup
     characters: List[CharacterIndex]
     mathml: str
+
 
 """
 KaTeX error color is set to white because this is a color where we'll minimize the chance of

--- a/data-processing/tests/mathml/relu.xml
+++ b/data-processing/tests/mathml/relu.xml
@@ -1,0 +1,13 @@
+<span class="katex">
+  <math xmlns="http://www.w3.org/1998/Math/MathML">
+    <semantics>
+      <mrow>
+        <mi s2:start="0" s2:end="1" s2:index="0">R</mi>
+        <mi s2:start="1" s2:end="2" s2:index="1">e</mi>
+        <mi s2:start="2" s2:end="3" s2:index="2">L</mi>
+        <mi s2:start="3" s2:end="4" s2:index="3">U</mi>
+      </mrow>
+      <annotation encoding="application/x-tex">ReLU</annotation>
+    </semantics>
+  </math>
+</span>

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -93,7 +93,7 @@ def test_parse_consecutive_mi():
 
   assert len(symbols) == 1
 
-  ReLU = symbols[0]
-  assert len(ReLU.children) == 0
-  assert len(ReLU.characters) == 4
-  assert ReLU.mathml == "<mi>ReLU</mi>"
+  relu = symbols[0]
+  assert len(relu.children) == 0
+  assert len(relu.characters) == 4
+  assert relu.mathml == "<mi>ReLU</mi>"

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -85,3 +85,8 @@ def test_get_symbol_children():
     assert len(t_sub_i.children) == 2
     assert t in t_sub_i.children
     assert i in t_sub_i.children
+
+def test_parse_consecutive_mi():
+  with open(get_test_path(os.path.join("mathml", "relu.xml"))) as mathml_file:
+        mathml = mathml_file.read()
+        symbols = get_symbols(mathml)

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -90,3 +90,10 @@ def test_parse_consecutive_mi():
   with open(get_test_path(os.path.join("mathml", "relu.xml"))) as mathml_file:
         mathml = mathml_file.read()
         symbols = get_symbols(mathml)
+
+  assert len(symbols) == 1
+
+  ReLU = symbols[0]
+  assert len(ReLU.children) == 0
+  assert len(ReLU.characters) == 4
+  assert ReLU.mathml == "<mi>ReLU</mi>"

--- a/data-processing/tests/test_parse_equation.py
+++ b/data-processing/tests/test_parse_equation.py
@@ -87,13 +87,13 @@ def test_get_symbol_children():
     assert i in t_sub_i.children
 
 def test_parse_consecutive_mi():
-  with open(get_test_path(os.path.join("mathml", "relu.xml"))) as mathml_file:
+    with open(get_test_path(os.path.join("mathml", "relu.xml"))) as mathml_file:
         mathml = mathml_file.read()
         symbols = get_symbols(mathml)
 
-  assert len(symbols) == 1
+    assert len(symbols) == 1
 
-  relu = symbols[0]
-  assert len(relu.children) == 0
-  assert len(relu.characters) == 4
-  assert relu.mathml == "<mi>ReLU</mi>"
+    relu = symbols[0]
+    assert len(relu.children) == 0
+    assert len(relu.characters) == 4
+    assert relu.mathml == "<mi>ReLU</mi>"


### PR DESCRIPTION
Merge consecutive <mi> tags that are also direct descendants of <mrow> tags as this is a good indicator that the consecutive <mi> tags should really have been considered one word. 

**Before:**
<img width="853" alt="Screen Shot 2020-03-09 at 7 47 04 PM" src="https://user-images.githubusercontent.com/22308211/76274874-0b48bf00-623f-11ea-8504-a1b35f401b28.png">

**After:**
<img width="1045" alt="Screen Shot 2020-03-09 at 7 13 20 PM" src="https://user-images.githubusercontent.com/22308211/76274882-0f74dc80-623f-11ea-8f76-b376be626304.png">
