### PR TITLE
Tooltip for citations without any linked paper

### DIFF
--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -16,9 +16,9 @@ export class Citation extends React.PureComponent<CitationProperties> {
           if (paper === undefined) {
             return (
               <div>
-                Sorry, we currently don't have any linked information for this paper yet.<br></br>
-                Let us know what went wrong by clicking on the icon below, so we could provide 
-                you with better reading experience in the future!
+                <p>Sorry, we currently don't have any linked information for this paper yet.</p>
+                <p>Let us know what went wrong by clicking on the icon below, so we could provide 
+                you with better reading experience in the future!</p>
               </div>
             )
           } else {

--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -13,31 +13,41 @@ export class Citation extends React.PureComponent<CitationProperties> {
       <ScholarReaderContext.Consumer>
         {({ papers, setJumpPaperId, setSelectedCitation }) => {
           const paper = papers[this.props.citation.paper];
-          return (
-            <div className="citation">
-              <p className="title">{paper.title}</p>
-              {paper.authors.length > 0 && (
-                <>
-                  by {paper.authors[0].name}{" "}
-                  {paper.authors.length > 1 && " et al."}
-                </>
-              )}
-              {paper.abstract !== null ? (
-                <div className="citation__abstract">
-                  {truncateText(paper.abstract, 400)}
-                  <span
-                    className="citation__abstract__sidebar-link"
-                    onClick={() => {
-                      setSelectedCitation(this.props.citation);
-                      setJumpPaperId(this.props.citation.paper);
-                    }}
-                  >
-                    (see more)
-                  </span>
-                </div>
-              ) : null}
-            </div>
-          );
+          if (paper === undefined) {
+            return (
+              <div>
+                Sorry, we currently don't have any linked information for this paper yet.<br></br>
+                Let us know what went wrong by clicking on the icon below, so we could provide 
+                you with better reading experience in the future!
+              </div>
+            )
+          } else {
+            return (
+              <div className="citation">
+                <p className="title">{paper.title}</p>
+                {paper.authors.length > 0 && (
+                  <>
+                    by {paper.authors[0].name}{" "}
+                    {paper.authors.length > 1 && " et al."}
+                  </>
+                )}
+                {paper.abstract !== null ? (
+                  <div className="citation__abstract">
+                    {truncateText(paper.abstract, 400)}
+                    <span
+                      className="citation__abstract__sidebar-link"
+                      onClick={() => {
+                        setSelectedCitation(this.props.citation);
+                        setJumpPaperId(this.props.citation.paper);
+                      }}
+                    >
+                      (see more)
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            );
+          }
         }}
       </ScholarReaderContext.Consumer>
     );

--- a/ui/src/style/tooltip.less
+++ b/ui/src/style/tooltip.less
@@ -28,6 +28,8 @@
 
   .tooltip-body__section:not(:first-of-type) {
     padding-top: @medium * 0.5;
+    padding-left: @tooltip-padding;
+    padding-right: @tooltip-padding;
   }
 
   .tooltip-body__header {
@@ -44,8 +46,8 @@
    * right edges of the text.
    */
   .tooltip-body__citation {
-    padding-left: 4px;
-    padding-right: 4px;
+    padding-left: @tooltip-padding;
+    padding-right: @tooltip-padding;
   }
 }
 

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -70,6 +70,7 @@
 
 @tooltip-paper-clipping-width: 320px;
 @tooltip-paper-clipping-height: 120px;
+@tooltip-padding: 4px;
 
 @drawer-paper-clipping-width: @paper-summary-width + (@paper-padding * 2);
 @drawer-paper-clipping-height: 200px;


### PR DESCRIPTION
This catches the fatal error threw when the api fails to fetch the paper linked from the server. With this implementation, a tooltip appears even when there isn't any linked information, and the user is encouraged to provide feedback on the tooltip and (hopefully) the missing paper.

(The screenshot is made by simulating the bug... it's not an actual bug now):
![1](https://user-images.githubusercontent.com/52334652/77133460-5f625900-6a20-11ea-815c-b35dba44463f.png)
