### PR TITLE
PDF Pipeline

### DIFF
--- a/data-processing/common/models.py
+++ b/data-processing/common/models.py
@@ -152,7 +152,8 @@ def init_database_connections(
     Initialize database connections.
     """
 
-    config = configparser.ConfigParser()
+    import os
+    config = configparser.ConfigParser(os.environ)
     config.read(DATABASE_CONFIG)
 
     # By default, data will be placed in a schema with the timestamp of the time that this

--- a/data-processing/common/types.py
+++ b/data-processing/common/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, NamedTuple, Optional
+from typing import Any, Callable, Dict, Set, List, NamedTuple, Optional
 
 """
 FILE PROCESSING
@@ -484,6 +484,14 @@ CharacterLocations = Dict[CharacterId, List[BoundingBox]]
 class CitationLocation(BoundingBox):
     key: str
     cluster_index: int
+
+@dataclass(frozen=True)
+class CitationData:
+    arxiv_id: ArxivId
+    s2_id: S2Id
+    citation_locations: Dict[str, Dict[int, Set[CitationLocation]]]
+    key_s2_ids: Dict[str, str]
+    s2_data: Dict[S2Id, SerializableReference]
 
 
 @dataclass(frozen=True)

--- a/data-processing/config.ini
+++ b/data-processing/config.ini
@@ -49,7 +49,7 @@ port = <input-port>
 [output-db]
 db_name = scholar-reader
 user = data-pipeline
-password = <substitute-with-password>
+password = %(READER_DB_PASSWORD)s
 host = scholar-reader.c5tvjmptvzlz.us-west-2.rds.amazonaws.com
 port = 5432
 

--- a/data-processing/entities/citations/commands/resolve_bibitems.py
+++ b/data-processing/entities/citations/commands/resolve_bibitems.py
@@ -7,6 +7,7 @@ from typing import Iterator, List, Set
 from common import directories, file_utils
 from common.commands.base import ArxivBatchCommand
 from common.types import ArxivId, Bibitem, BibitemMatch, SerializableReference
+from ..utils import extract_ngrams, ngram_sim
 
 
 @dataclass(frozen=True)
@@ -21,23 +22,6 @@ The title and authors must have at least this much overlap with the bibitem's te
 the similarity metric below to be considered a match.
 """
 SIMILARITY_THRESHOLD = 0.5
-
-
-def extract_ngrams(s: str, n: int = 3) -> Set[str]:
-    """
-    This and the 'ngram_sim' method below were provided by Kyle Lo.
-    """
-    s = re.sub(r"\W", "", s.lower())
-    ngrams = zip(*[s[i:] for i in range(n)])
-    return {"".join(ngram) for ngram in ngrams}
-
-
-def ngram_sim(s1: str, s2: str) -> float:
-    s1_grams = extract_ngrams(s1)
-    s2_grams = extract_ngrams(s2)
-    if len(s1_grams) == 0 or len(s2_grams) == 0:
-        return 0
-    return len(s1_grams.intersection(s2_grams)) / min(len(s1_grams), len(s2_grams))
 
 
 class ResolveBibitems(ArxivBatchCommand[MatchTask, BibitemMatch]):

--- a/data-processing/entities/citations/commands/upload_citations.py
+++ b/data-processing/entities/citations/commands/upload_citations.py
@@ -12,24 +12,14 @@ from common.commands.database import DatabaseUploadCommand
 from common.models import BoundingBox as BoundingBoxModel
 from common.models import (Citation, CitationPaper, Entity, EntityBoundingBox,
                            Paper, Summary, output_database)
-from common.types import (ArxivId, BibitemMatch, CitationLocation,
+from common.types import (ArxivId, BibitemMatch, CitationLocation, CitationData,
                           SerializableReference)
 
-from ..utils import load_located_citations
+from ..utils import load_located_citations, upload_citations
 
 CitationKey = str
 LocationIndex = int
 S2Id = str
-
-
-@dataclass(frozen=True)
-class CitationData:
-    arxiv_id: ArxivId
-    s2_id: S2Id
-    citation_locations: Dict[CitationKey, Dict[LocationIndex, Set[CitationLocation]]]
-    key_s2_ids: Dict[CitationKey, S2Id]
-    s2_data: Dict[S2Id, SerializableReference]
-
 
 class UploadCitations(DatabaseUploadCommand[CitationData, None]):
     @staticmethod
@@ -105,71 +95,4 @@ class UploadCitations(DatabaseUploadCommand[CitationData, None]):
         yield None
 
     def save(self, item: CitationData, _: None) -> None:
-
-        arxiv_id = item.arxiv_id
-        s2_id = item.s2_id
-        citation_locations = item.citation_locations
-        key_s2_ids = item.key_s2_ids
-        s2_data = item.s2_data
-
-        try:
-            paper = Paper.get(Paper.s2_id == s2_id)
-        except Paper.DoesNotExist:
-            paper = Paper.create(s2_id=s2_id, arxiv_id=arxiv_id)
-
-        for citation_key, locations in citation_locations.items():
-
-            if citation_key in key_s2_ids:
-                s2_id = key_s2_ids[citation_key]
-                if s2_id in s2_data:
-                    paper_data = s2_data[s2_id]
-
-                    try:
-                        cited_paper = Paper.get(Paper.s2_id == s2_id)
-                    except Paper.DoesNotExist:
-                        cited_paper = Paper.create(
-                            s2_id=s2_id, arxiv_id=paper_data.arxivId or None
-                        )
-
-                    try:
-                        Summary.get(Summary.paper == cited_paper)
-                    except Summary.DoesNotExist:
-                        Summary.create(
-                            paper=cited_paper,
-                            title=paper_data.title,
-                            authors=paper_data.authors,
-                            doi=paper_data.doi or None,
-                            venue=paper_data.venue or None,
-                            year=paper_data.year,
-                        )
-
-            for location_set in locations.values():
-                citation = Citation.create(paper=paper)
-                try:
-                    with output_database.atomic():
-                        CitationPaper.create(paper=cited_paper, citation=citation)
-                except IntegrityError:
-                    logging.warning(  # pylint: disable=logging-not-lazy
-                        (
-                            "Cited paper %s and citation %s are already linked. This suggests a bug in "
-                            + "the citation resolution code; perhaps multiple citation keys were "
-                            + "matched to the same paper?"
-                        ),
-                        cited_paper.arxiv_id,
-                        citation.id,
-                    )
-
-                entity = Entity.create(
-                    type="citation", source="tex-pipeline", entity_id=citation.id
-                )
-
-                for location in location_set:
-                    bounding_box = BoundingBoxModel.create(
-                        page=location.page,
-                        left=location.left,
-                        top=location.top,
-                        width=location.width,
-                        height=location.height,
-                    )
-
-                    EntityBoundingBox.create(bounding_box=bounding_box, entity=entity)
+        upload_citations(item)

--- a/data-processing/entities/citations/utils.py
+++ b/data-processing/entities/citations/utils.py
@@ -1,15 +1,35 @@
 import logging
 import os
 from typing import Dict, Optional, Set
+from peewee import IntegrityError
+import re
 
 from common import directories, file_utils
-from common.types import ArxivId, CitationLocation
+from common.models import BoundingBox as BoundingBoxModel
+from common.models import Paper, Citation, CitationPaper, Entity, EntityBoundingBox, Summary, output_database
+from common.types import ArxivId, CitationLocation, CitationData
 
 CitationKey = str
 LocationIndex = int
 
 Citations = Dict[CitationKey, Dict[LocationIndex, Set[CitationLocation]]]
 
+
+def extract_ngrams(s: str, n: int = 3) -> Set[str]:
+    """
+    This and the 'ngram_sim' method below were provided by Kyle Lo.
+    """
+    s = re.sub(r"\W", "", s.lower())
+    ngrams = zip(*[s[i:] for i in range(n)])
+    return {"".join(ngram) for ngram in ngrams}
+
+
+def ngram_sim(s1: str, s2: str) -> float:
+    s1_grams = extract_ngrams(s1)
+    s2_grams = extract_ngrams(s2)
+    if len(s1_grams) == 0 or len(s2_grams) == 0:
+        return 0
+    return len(s1_grams.intersection(s2_grams)) / min(len(s1_grams), len(s2_grams))
 
 def load_located_citations(arxiv_id: ArxivId) -> Optional[Citations]:
     citation_locations: Citations = {}
@@ -29,3 +49,73 @@ def load_located_citations(arxiv_id: ArxivId) -> Optional[Citations]:
         citation_locations[location.key][location.cluster_index].add(location)
 
     return citation_locations
+
+def upload_citations(item: CitationData, source: str = "tex-pipeline") -> None:
+        arxiv_id = item.arxiv_id
+        s2_id = item.s2_id
+        citation_locations = item.citation_locations
+        key_s2_ids = item.key_s2_ids
+        s2_data = item.s2_data
+
+        try:
+            paper = Paper.get(Paper.s2_id == s2_id)
+        except Paper.DoesNotExist:
+            paper = Paper.create(s2_id=s2_id, arxiv_id=arxiv_id)
+
+        for citation_key, locations in citation_locations.items():
+            cited_paper = None
+            if citation_key in key_s2_ids:
+                s2_id = key_s2_ids[citation_key]
+                if s2_id in s2_data:
+                    paper_data = s2_data[s2_id]
+
+                    try:
+                        cited_paper = Paper.get(Paper.s2_id == s2_id)
+                    except Paper.DoesNotExist:
+                        cited_paper = Paper.create(
+                            s2_id=s2_id, arxiv_id=paper_data.arxivId or None
+                        )
+
+                    try:
+                        Summary.get(Summary.paper == cited_paper)
+                    except Summary.DoesNotExist:
+                        Summary.create(
+                            paper=cited_paper,
+                            title=paper_data.title,
+                            authors=paper_data.authors,
+                            doi=paper_data.doi or None,
+                            venue=paper_data.venue or None,
+                            year=paper_data.year,
+                        )
+
+            for location_set in locations.values():
+                citation = Citation.create(paper=paper)
+                if cited_paper:
+                    try:
+                        with output_database.atomic():
+                            CitationPaper.create(paper=cited_paper, citation=citation)
+                    except IntegrityError:
+                        logging.warning(  # pylint: disable=logging-not-lazy
+                            (
+                                "Cited paper %s and citation %s are already linked. This suggests a bug in "
+                                + "the citation resolution code; perhaps multiple citation keys were "
+                                + "matched to the same paper?"
+                            ),
+                            cited_paper.arxiv_id,
+                            citation.id,
+                        )
+
+                entity = Entity.create(
+                    type="citation", source=source, entity_id=citation.id
+                )
+
+                for location in location_set:
+                    bounding_box = BoundingBoxModel.create(
+                        page=location.page,
+                        left=location.left,
+                        top=location.top,
+                        width=location.width,
+                        height=location.height,
+                    )
+
+                    EntityBoundingBox.create(bounding_box=bounding_box, entity=entity)

--- a/data-processing/entities/symbols/commands/upload_symbols.py
+++ b/data-processing/entities/symbols/commands/upload_symbols.py
@@ -1,59 +1,26 @@
 import logging
 import os.path
-from dataclasses import dataclass
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator
 
 from common import directories, file_utils
 from common.commands.database import DatabaseUploadCommand
-from common.models import BoundingBox as BoundingBoxModel
-from common.models import Entity, EntityBoundingBox, output_database
 from common.s2_data import get_s2_id
 from common.types import (
-    ArxivId,
     BoundingBox,
     Match,
     Matches,
-    MathML,
     SymbolId,
     SymbolLocation,
-    SymbolWithId,
 )
 from entities.sentences.commands.find_entity_sentences import EntitySentencePairIds
 from entities.sentences.upload import SentenceIdAndModelId
 
-from ..models import MathMl as MathMlModel
-from ..models import MathMlMatch, Paper
-from ..models import Symbol as SymbolModel
-from ..models import SymbolChild, SymbolSentence
+from ..types import SymbolData, SymbolKey, SentenceKey
+from ..utils import upload_symbols
 
 S2Id = str
 Hue = float
 SentenceModelId = str
-
-
-@dataclass(frozen=True)
-class SymbolKey:
-    arxiv_id: ArxivId
-    tex_path: str
-    equation_index: int
-    token_index: int
-
-
-@dataclass(frozen=True)
-class SentenceKey:
-    tex_path: str
-    sentence_id: str
-
-
-@dataclass(frozen=True)
-class SymbolData:
-    arxiv_id: ArxivId
-    s2_id: S2Id
-    symbols_with_ids: List[SymbolWithId]
-    boxes: Dict[SymbolId, BoundingBox]
-    symbol_sentence_model_ids: Dict[SymbolId, SentenceModelId]
-    matches: Matches
-
 
 class UploadSymbols(DatabaseUploadCommand[SymbolData, None]):
     @staticmethod
@@ -181,124 +148,4 @@ class UploadSymbols(DatabaseUploadCommand[SymbolData, None]):
         yield None
 
     def save(self, item: SymbolData, _: None) -> None:
-
-        arxiv_id = item.arxiv_id
-        s2_id = item.s2_id
-        symbols_with_ids = item.symbols_with_ids
-        boxes = item.boxes
-        matches = item.matches
-
-        try:
-            paper = Paper.get(Paper.s2_id == s2_id)
-        except Paper.DoesNotExist:
-            paper = Paper.create(s2_id=s2_id, arxiv_id=arxiv_id)
-
-        # Load MathML models into cache; they will be needed for creating multiple symbols.
-        mathml_cache: Dict[MathML, MathMlModel] = {}
-        mathml_equations = {swi.symbol.mathml for swi in symbols_with_ids}
-        for mathml, mathml_matches in matches.items():
-            mathml_equations.update(
-                {mathml}.union({match.matching_mathml for match in mathml_matches})
-            )
-        for mathml in mathml_equations:
-            if mathml not in mathml_cache:
-                try:
-                    mathml_model = MathMlModel.get(MathMlModel.mathml == mathml)
-                except MathMlModel.DoesNotExist:
-                    mathml_model = MathMlModel.create(mathml=mathml)
-                mathml_cache[mathml] = mathml_model
-
-        # Upload MathML search results.
-        mathml_match_models = []
-        for mathml, mathml_matches in matches.items():
-            for match in mathml_matches:
-                mathml_match_models.append(
-                    MathMlMatch(
-                        paper=paper,
-                        mathml=mathml_cache[mathml],
-                        match=mathml_cache[match.matching_mathml],
-                        rank=match.rank,
-                    )
-                )
-        with output_database.atomic():
-            MathMlMatch.bulk_create(mathml_match_models, 200)
-
-        # Create all symbols in bulk. This lets us resolve their IDs before we start referring to
-        # them from other tables. It also lets us refer to their models in the parent-child table.
-        symbol_models: Dict[SymbolId, SymbolModel] = {}
-        symbol_models_by_symbol_object_id: Dict[int, SymbolModel] = {}
-
-        for symbol_with_id in symbols_with_ids:
-            symbol = symbol_with_id.symbol
-            symbol_id = symbol_with_id.symbol_id
-            mathml_model = mathml_cache[symbol.mathml]
-            symbol_model = SymbolModel(paper=paper, mathml=mathml_model)
-            symbol_models[symbol_id] = symbol_model
-            symbol_models_by_symbol_object_id[id(symbol)] = symbol_model
-
-        with output_database.atomic():
-            SymbolModel.bulk_create(symbol_models.values(), 300)
-
-        # Upload bounding boxes for symbols. 'bulk_create' must have already been called on the
-        # the symbol models to make sure their model IDs can be used here.
-        entities = []
-        entity_bounding_boxes = []
-        bounding_boxes = []
-        for symbol_with_id in symbols_with_ids:
-
-            symbol_id = symbol_with_id.symbol_id
-            symbol_model = symbol_models[symbol_id]
-
-            box = boxes.get(symbol_id)
-            if box is not None:
-                entity = Entity(
-                    type="symbol", source="tex-pipeline", entity_id=symbol_model.id
-                )
-                entities.append(entity)
-                bounding_box = BoundingBoxModel(
-                    page=box.page,
-                    left=box.left,
-                    top=box.top,
-                    width=box.width,
-                    height=box.height,
-                )
-                bounding_boxes.append(bounding_box)
-
-                entity_bounding_box = EntityBoundingBox(
-                    bounding_box=bounding_box, entity=entity
-                )
-                entity_bounding_boxes.append(entity_bounding_box)
-
-        with output_database.atomic():
-            BoundingBoxModel.bulk_create(bounding_boxes, 100)
-        with output_database.atomic():
-            Entity.bulk_create(entities, 300)
-        with output_database.atomic():
-            EntityBoundingBox.bulk_create(entity_bounding_boxes, 300)
-
-        # Upload parent-child relationships between symbols.
-        symbol_child_models = []
-        for symbol_with_id in symbols_with_ids:
-
-            symbol = symbol_with_id.symbol
-            symbol_id = symbol_with_id.symbol_id
-            symbol_model = symbol_models[symbol_id]
-
-            for child in symbol.children:
-                child_model = symbol_models_by_symbol_object_id[id(child)]
-                symbol_child_models.append(
-                    SymbolChild(parent=symbol_model, child=child_model)
-                )
-        with output_database.atomic():
-            SymbolChild.bulk_create(symbol_child_models, 300)
-
-        # Upload links between symbols and the sentences they appear in.
-        symbol_sentence_models = []
-        for symbol_id, sentence_model_id in item.symbol_sentence_model_ids.items():
-            symbol_model = symbol_models[symbol_id]
-            symbol_sentence_models.append(
-                SymbolSentence(symbol=symbol_model, sentence_id=sentence_model_id)
-            )
-
-        with output_database.atomic():
-            SymbolSentence.bulk_create(symbol_sentence_models, 300)
+        upload_symbols(item)

--- a/data-processing/entities/symbols/types.py
+++ b/data-processing/entities/symbols/types.py
@@ -1,0 +1,27 @@
+from typing import List, Dict
+
+from dataclasses import dataclass
+from common.types import ArxivId, SymbolWithId, SymbolId, BoundingBox, Matches, S2Id
+
+@dataclass(frozen=True)
+class SymbolKey:
+    arxiv_id: ArxivId
+    tex_path: str
+    equation_index: int
+    token_index: int
+
+
+@dataclass(frozen=True)
+class SentenceKey:
+    tex_path: str
+    sentence_id: str
+
+
+@dataclass(frozen=True)
+class SymbolData:
+    arxiv_id: ArxivId
+    s2_id: S2Id
+    symbols_with_ids: List[SymbolWithId]
+    boxes: Dict[SymbolId, BoundingBox]
+    symbol_sentence_model_ids: Dict[SymbolId, str]
+    matches: Matches

--- a/data-processing/entities/symbols/utils.py
+++ b/data-processing/entities/symbols/utils.py
@@ -1,0 +1,132 @@
+from typing import List, Dict
+
+from .types import SymbolData, SymbolKey, SentenceKey
+from .models import MathMl as MathMlModel
+from .models import MathMlMatch, SymbolChild, SymbolSentence
+from .models import Symbol as SymbolModel
+from common.types import MathML, SymbolId
+from common.models import BoundingBox as BoundingBoxModel
+from common.models import output_database, Paper, Entity, EntityBoundingBox
+
+
+def upload_symbols(item: SymbolData, source: str = "tex-pipeline") -> None:
+    arxiv_id = item.arxiv_id
+    s2_id = item.s2_id
+    symbols_with_ids = item.symbols_with_ids
+    boxes = item.boxes
+    matches = item.matches
+
+    try:
+        paper = Paper.get(Paper.s2_id == s2_id)
+    except Paper.DoesNotExist:
+        paper = Paper.create(s2_id=s2_id, arxiv_id=arxiv_id)
+
+    # Load MathML models into cache; they will be needed for creating multiple symbols.
+    mathml_cache: Dict[MathML, MathMlModel] = {}
+    mathml_equations = {swi.symbol.mathml for swi in symbols_with_ids}
+    for mathml, mathml_matches in matches.items():
+        mathml_equations.update(
+            {mathml}.union({match.matching_mathml for match in mathml_matches})
+        )
+    for mathml in mathml_equations:
+        if mathml not in mathml_cache:
+            try:
+                mathml_model = MathMlModel.get(MathMlModel.mathml == mathml)
+            except MathMlModel.DoesNotExist:
+                mathml_model = MathMlModel.create(mathml=mathml)
+            mathml_cache[mathml] = mathml_model
+
+    # Upload MathML search results.
+    mathml_match_models = []
+    for mathml, mathml_matches in matches.items():
+        for match in mathml_matches:
+            mathml_match_models.append(
+                MathMlMatch(
+                    paper=paper,
+                    mathml=mathml_cache[mathml],
+                    match=mathml_cache[match.matching_mathml],
+                    rank=match.rank,
+                )
+            )
+    with output_database.atomic():
+        MathMlMatch.bulk_create(mathml_match_models, 200)
+
+    # Create all symbols in bulk. This lets us resolve their IDs before we start referring to
+    # them from other tables. It also lets us refer to their models in the parent-child table.
+    symbol_models: Dict[SymbolId, SymbolModel] = {}
+    symbol_models_by_symbol_object_id: Dict[int, SymbolModel] = {}
+
+    for symbol_with_id in symbols_with_ids:
+        symbol = symbol_with_id.symbol
+        symbol_id = symbol_with_id.symbol_id
+        mathml_model = mathml_cache[symbol.mathml]
+        symbol_model = SymbolModel(paper=paper, mathml=mathml_model)
+        symbol_models[symbol_id] = symbol_model
+        symbol_models_by_symbol_object_id[id(symbol)] = symbol_model
+
+    with output_database.atomic():
+        SymbolModel.bulk_create(symbol_models.values(), 300)
+
+    # Upload bounding boxes for symbols. 'bulk_create' must have already been called on the
+    # the symbol models to make sure their model IDs can be used here.
+    entities = []
+    entity_bounding_boxes = []
+    bounding_boxes = []
+    for symbol_with_id in symbols_with_ids:
+
+        symbol_id = symbol_with_id.symbol_id
+        symbol_model = symbol_models[symbol_id]
+
+        box = boxes.get(symbol_id)
+        if box is not None:
+            entity = Entity(
+                type="symbol", source=source, entity_id=symbol_model.id
+            )
+            entities.append(entity)
+            bounding_box = BoundingBoxModel(
+                page=box.page,
+                left=box.left,
+                top=box.top,
+                width=box.width,
+                height=box.height,
+            )
+            bounding_boxes.append(bounding_box)
+
+            entity_bounding_box = EntityBoundingBox(
+                bounding_box=bounding_box, entity=entity
+            )
+            entity_bounding_boxes.append(entity_bounding_box)
+
+    with output_database.atomic():
+        BoundingBoxModel.bulk_create(bounding_boxes, 100)
+    with output_database.atomic():
+        Entity.bulk_create(entities, 300)
+    with output_database.atomic():
+        EntityBoundingBox.bulk_create(entity_bounding_boxes, 300)
+
+    # Upload parent-child relationships between symbols.
+    symbol_child_models = []
+    for symbol_with_id in symbols_with_ids:
+
+        symbol = symbol_with_id.symbol
+        symbol_id = symbol_with_id.symbol_id
+        symbol_model = symbol_models[symbol_id]
+
+        for child in symbol.children:
+            child_model = symbol_models_by_symbol_object_id[id(child)]
+            symbol_child_models.append(
+                SymbolChild(parent=symbol_model, child=child_model)
+            )
+    with output_database.atomic():
+        SymbolChild.bulk_create(symbol_child_models, 300)
+
+    # Upload links between symbols and the sentences they appear in.
+    symbol_sentence_models = []
+    for symbol_id, sentence_model_id in item.symbol_sentence_model_ids.items():
+        symbol_model = symbol_models[symbol_id]
+        symbol_sentence_models.append(
+            SymbolSentence(symbol=symbol_model, sentence_id=sentence_model_id)
+        )
+
+    with output_database.atomic():
+        SymbolSentence.bulk_create(symbol_sentence_models, 300)

--- a/data-processing/pdf/__init__..py
+++ b/data-processing/pdf/__init__..py
@@ -1,0 +1,1 @@
+# For extraction of entities directly from a PDF

--- a/data-processing/pdf/grobid_client.py
+++ b/data-processing/pdf/grobid_client.py
@@ -1,0 +1,24 @@
+import requests
+import json
+
+def get_pdf_structure(pdf_file):
+    """
+    Get parsed PDF data from a local instance of the Grobid service
+    :param pdf_file:
+    :return:
+    """
+    try:
+        files = {'input':(pdf_file, open(pdf_file,'rb'), 'application/pdf',{'Expires':'0'})}
+        resp = requests.post('http://localhost:8070/api/processPdfStructure',files=files)
+
+        if resp.status_code == 200:
+            return json.loads(resp.text)
+        else:
+            raise Exception("Grobid returned status code {}".format(resp.status_code))
+    except requests.exceptions.ConnectionError:
+        msg="""Could not connect to local grobid service.
+         To start the service, run 'docker pull 896129387501.dkr.ecr.us-west-2.amazonaws.com/grobid-server:pdf-structure' 
+         followed by 'docker run --rm -d --name local-grobid -p 8070:8070 -p 8071:8071 896129387501.dkr.ecr.us-west-2.amazonaws.com/grobid-server:pdf-structure
+        """
+        raise Exception(msg)
+

--- a/data-processing/pdf/process_pdf.py
+++ b/data-processing/pdf/process_pdf.py
@@ -1,0 +1,239 @@
+import requests
+import logging
+from typing import List, Dict
+import sys
+from tempfile import TemporaryDirectory
+import subprocess
+import time
+
+import pdf.grobid_client
+from common.models import BoundingBox as BoundingBoxModel
+from common.models import init_database_connections
+from common.types import CitationData, CitationLocation, SerializableReference, BoundingBox, Matches, Match, Symbol
+from entities.symbols.types import SymbolData, SymbolWithId, SymbolId
+from entities.citations.utils import upload_citations, extract_ngrams, ngram_sim
+from entities.symbols.utils import upload_symbols
+
+class PdfStructureParser:
+    def __init__(self, pdf_hash, structure_map):
+        self.pdf_hash = pdf_hash
+        self.structure_map = structure_map
+        self.pages = structure_map['tokens']['pages']
+        self.page_sizes = dict((p['page']['pageNumber'], p['page']) for p in self.pages)
+        self.page_indices = dict((p['page']['pageNumber'], i) for i,p in enumerate(self.pages))
+        self.elements = structure_map['elements']['elementTypes']
+        self.references = None
+
+    def find_token(self, index):
+        for p in self.pages:
+            if (index < len(p['tokens'])):
+                return p['page'], p['tokens'][index]
+            else:
+                index -= len(p['tokens'])
+        return None
+
+
+    def get_text(self,spans):
+        text = []
+        for s in spans:
+            direct = s.get('dehyphenizedText')
+            if direct:
+                text += direct
+            else:
+                for i in range(s['left'], s['right']):
+                    page, token = self.find_token(i)
+                    text.append(token['text'])
+        return ' '.join(text)
+
+    def union(self, bbox1: BoundingBoxModel, bbox2: BoundingBoxModel):
+        if not bbox1:
+            return bbox2
+        if not bbox2:
+            return bbox1
+        x1 = min(bbox1.left,bbox2.left)
+        y1 = min(bbox1.top,bbox2.top)
+        x2 = max(bbox1.left+bbox1.width, bbox2.left+bbox2.width)
+        y2 = max(bbox1.top+bbox1.height, bbox2.top+bbox2.height)
+        return BoundingBoxModel(page = bbox1.page,
+                                left = x1, top = y1, width = x2-x1, height=y2-y1)
+
+    @staticmethod
+    def should_combine(bbox1: BoundingBoxModel, bbox2: BoundingBoxModel):
+        return bbox1.page == bbox2.page and (
+            abs(bbox1.top - bbox2.top) < 4 # Same y-coordinate
+        ) and (
+            abs(bbox2.left - bbox1.left - bbox1.width) < 15 # To the right
+        )
+
+    def get_bounding_boxes(self, spans):
+        bboxes = []
+        for s in spans:
+            bbox = None
+            for i in range(s['left'], s['right']):
+                page, token = self.find_token(i)
+                page_index = self.page_indices[page['pageNumber']]
+                token_bbox = BoundingBoxModel(
+                    page = page_index,
+                    left = token['x'],
+                    top = token['y'],
+                    width = token['width'],
+                    height=token['height']
+                )
+                if not bbox:
+                    bbox = token_bbox
+                elif self.should_combine(bbox, token_bbox):
+                    bbox = self.union(bbox, token_bbox)
+                else:
+                    bboxes.append(bbox)
+                    bbox = token_bbox
+            if bbox:
+                bboxes.append(bbox)
+        return bboxes
+
+
+    def find_cited_paper(self, bib_item_title):
+        if self.references is None:
+            resp = requests.get(f"https://api.semanticscholar.org/v1/paper/{self.pdf_hash}")
+            if resp.ok:
+                self.references = resp.json()['references']
+            else:
+                logging.warning('Got status %s for paper %s',resp.status_code, pdf_hash)
+                self.references = []
+
+        max_similarity = 0.0
+        best_matching_paper = None
+        for reference_data in self.references:
+            reference_title = reference_data['title']
+            similarity = ngram_sim(reference_title, bib_item_title)
+            if similarity > 0.5 and similarity > max_similarity:
+                max_similarity = similarity
+                best_matching_paper = reference_data
+
+        return best_matching_paper
+
+    def get_symbols(self) -> SymbolData:
+        symbols_with_ids: List[SymbolWithId] = []
+        boxes: Dict[SymbolId, BoundingBox] = {}
+        matches: Matches = {}
+        symbol_index = 0
+        for sym in self.elements['<symbol>']:
+            id = sym['tags'].get('id')
+            if id:
+                spans = sym['spans']
+                bboxes = self.get_bounding_boxes(spans)
+                mock_math_ml = '<pdf_symbol>{}</pdf_symbol>'.format(id)
+                symbol = Symbol([], mock_math_ml, [])
+                symbol_id = SymbolId(id, None, symbol_index)
+                symbols_with_ids.append(SymbolWithId(symbol_id, symbol))
+                if bboxes:
+                    box = bboxes[0]
+                    page = self.page_sizes[box.page]
+                    box.page = self.page_indices[box.page]
+                    box.left /= page['width']
+                    box.top /= page['height']
+                    box.width /= page['width']
+                    box.height /= page['height']
+                    boxes[symbol_id] = box
+                match = Match(mock_math_ml, mock_math_ml, 1)
+                matches.setdefault(mock_math_ml,[]).append(match)
+                symbol_index += 1
+        return SymbolData(
+            arxiv_id=None,
+            s2_id=pdf_hash,
+            symbols_with_ids=symbols_with_ids,
+            boxes = boxes,
+            symbol_sentence_model_ids={},
+            matches=matches
+        )
+
+    def get_citations(self) -> CitationData:
+        locations = {}
+        s2_ids_of_citations = {}
+        s2_data = {}
+
+        bib_item_titles = {}
+        for ref in self.elements.get('<bibItem_title>', []):
+            id = ref['tags'].get('id')
+            if id:
+                bib_item_titles[id] = self.get_text(ref['spans'])
+
+        citation_index = 0
+        for cit in self.elements.get('<citation_marker>', []):
+            ref = cit['tags'].get('ref')
+            spans = cit['spans']
+            if ref:
+                bib_item_title = bib_item_titles.get(ref)
+                if bib_item_title:
+                    cited_paper = self.find_cited_paper(bib_item_title)
+                    if cited_paper:
+                        cited_paper_id = cited_paper['paperId']
+                        s2_ids_of_citations[ref] = cited_paper_id
+                        if cited_paper_id not in s2_data:
+                            authors = ','.join(a['name'] for a in cited_paper['authors'])
+                            s2_data[cited_paper_id] = SerializableReference(
+                                s2_id = cited_paper_id,
+                                arxivId=cited_paper.get('arxivId'),
+                                doi = cited_paper.get('doi'),
+                                title = cited_paper.get('title'),
+                                authors=authors,
+                                venue = cited_paper.get('venue'),
+                                year = cited_paper.get('year')
+                            )
+
+                citation_locations = set()
+                for box in self.get_bounding_boxes(spans):
+                        page = self.page_sizes[box.page]
+                        loc = CitationLocation(key=ref,
+                                     cluster_index=citation_index,
+                                     page=self.page_indices[box.page],
+                                     left=box.left / page['width'],
+                                     top=box.top / page['height'],
+                                     width=box.width / page['width'],
+                                     height=box.height / page['height'])
+                        citation_locations.add(loc)
+                locations.setdefault(ref, {})[citation_index] = citation_locations
+
+            citation_index += 1
+
+        return CitationData(
+            arxiv_id = None,
+            s2_id = pdf_hash,
+            citation_locations=locations,
+            key_s2_ids=s2_ids_of_citations,
+            s2_data = s2_data
+        )
+
+
+    def upload(self):
+        citations = self.get_citations()
+        upload_citations(citations, 'pdf-pipeline')
+        symbols = self.get_symbols()
+        upload_symbols(symbols,'pdf-pipeline')
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    pdf_hashes = ['8c53cd64e46cf382bf81ce2c4e0087ef31351919']
+    if sys.argv[1:]:
+        pdf_hashes = [s.strip() for s in open(sys.argv[1]).readlines()]
+
+    init_database_connections('public')
+    with TemporaryDirectory() as tempdir:
+        for pdf_hash in pdf_hashes:
+            start_time = time.time()
+            logging.info("Processing PDF %s", pdf_hash)
+            try:
+                pdf_file = "{}/{}.pdf".format(tempdir, pdf_hash)
+                try:
+                    subprocess.check_call([
+                        "aws", "s3", "cp", "s3://ai2-s2-pdfs/{}/{}.pdf".format(pdf_hash[:4], pdf_hash[4:]), pdf_file
+                    ])
+                except:
+                    subprocess.check_call([
+                        "aws", "s3", "cp", "s3://ai2-s2-pdfs-private/{}/{}.pdf".format(pdf_hash[:4], pdf_hash[4:]), pdf_file
+                    ])
+                s = pdf.grobid_client.get_pdf_structure(pdf_file)
+                PdfStructureParser(pdf_hash, s).upload()
+                logging.info("Finished in %s second", time.time() - start_time)
+            except Exception:
+                logging.exception('Error processing {}'.format(pdf_hash))


### PR DESCRIPTION
Populate the scholar-reader database with citations and symbols from the Grobid-based PDF processing pipeline. Calls the Grobid API as a service and converts the Grobid annotations and token bounding boxes to reader entities.

Depends on [these changes](https://github.com/allenai/grobid/pull/10) to Grobid.

Had to do some mild refactoring of the existing pipeline code to enable this alternate entry point. Mostly this involves moving existing methods into different modules, like some data classes and the `upload` methods, which have been put into the `util` modules.