### PR TITLE
Add symbol search

### DIFF
--- a/ui/src/FindBar.tsx
+++ b/ui/src/FindBar.tsx
@@ -129,7 +129,7 @@ export class FindBar extends React.PureComponent<FindBarProps, FindBarState> {
       const newEntityId = order[
         this.wrapIndex(order.indexOf(this.context.selectedEntityId || '') + 1, order.length)
       ];
-      jumpToBoundingBox(matches.get(newEntityId));
+      // jumpToBoundingBox(matches.get(newEntityId));
       this.context.setSelectedEntity(newEntityId, "symbol");
     } else {
       this.dispatchEventToPdfJs("findagain");
@@ -144,7 +144,7 @@ export class FindBar extends React.PureComponent<FindBarProps, FindBarState> {
       const newEntityId = order[
         this.wrapIndex(order.indexOf(this.context.selectedEntityId || '') - 1, order.length)
       ];
-      jumpToBoundingBox(matches.get(newEntityId));
+      // jumpToBoundingBox(matches.get(newEntityId));
       this.context.setSelectedEntity(newEntityId, "symbol");
     } else {
       this.dispatchEventToPdfJs("findagain", true);

--- a/ui/src/FindBar.tsx
+++ b/ui/src/FindBar.tsx
@@ -150,9 +150,11 @@ export class FindBar extends React.PureComponent<FindBarProps, FindBarState> {
   }
 
   moveToNextSymbol(movement: number) {
-    const { matches, mappingToBounds, selectedSymbol } = this.props;
+    const { matches, mappingToBounds } = this.props;
+
+    // -1 since currentMatch is not 0 indexed.
     const newEntityId = matches[
-      this.wrapIndex(matches.indexOf(selectedSymbol || '') + movement, matches.length)
+      this.wrapIndex((this.state.currentMatch || 0) - 1 + movement, matches.length)
     ];
    
     const newBoxId = mappingToBounds.has(newEntityId) ? mappingToBounds.get(newEntityId).id : '';
@@ -228,7 +230,7 @@ export class FindBar extends React.PureComponent<FindBarProps, FindBarState> {
 
   render() {
     if (this.state.mode === 'hidden') {
-      return <div></div>
+      return null;
     }
     return (
       <div className="find-bar">

--- a/ui/src/FindBarString.tsx
+++ b/ui/src/FindBarString.tsx
@@ -27,7 +27,6 @@ export class FindBarString extends React.PureComponent<FindBarStringProps, FindB
   context!: React.ContextType<typeof ScholarReaderContext>;
 
   componentDidMount() {
-    console.log('caused mount')
     /*
      * XXX(andrewhead): Find a cleaner way to plug into the pdf.js find controller.
      * See https://github.com/allenai/scholar-reader/issues/96 for a discussion of alternatives.
@@ -61,9 +60,11 @@ export class FindBarString extends React.PureComponent<FindBarStringProps, FindB
       pdfJsEventBus: pdfViewerApplicationAny.eventBus,
     });
 
+    // This is safe since componentDidMount will
+    // be called after one render.
     if (this.queryElement) {
       this.queryElement.focus();
-			this.queryElement.select();
+      this.queryElement.select();
     }
   }
 

--- a/ui/src/FindBarSymbol.tsx
+++ b/ui/src/FindBarSymbol.tsx
@@ -34,7 +34,7 @@ export class FindBarSymbol extends React.PureComponent<FindBarProps, {}> {
 
   moveToNextSymbol(currId: string, movement: number, e: React.SyntheticEvent) {
     const { matches, mappingToBounds } = this.props;
-		const currentMatch = matches.indexOf(currId);
+    const currentMatch = matches.indexOf(currId);
 
     const newEntityId = matches[
       this.wrapIndex((currentMatch || 0) + movement, matches.length)
@@ -42,7 +42,7 @@ export class FindBarSymbol extends React.PureComponent<FindBarProps, {}> {
    
     const newBoxId = mappingToBounds.has(newEntityId) ? mappingToBounds.get(newEntityId).id : '';
     this.selectSymbol(newEntityId, newBoxId);
-		e.preventDefault();
+    e.preventDefault();
   }
 
   closeFinder = (e: React.SyntheticEvent) => {
@@ -65,8 +65,8 @@ export class FindBarSymbol extends React.PureComponent<FindBarProps, {}> {
     if ((matches.length || 0) > MATCH_COUNT_LIMIT) {
       return `More than ${MATCH_COUNT_LIMIT} matches`;
     }
-
-		const currentMatch = matches.indexOf(selectedSymbol) + 1;
+    
+    const currentMatch = matches.indexOf(selectedSymbol) + 1;
     return `${currentMatch} of ${matches.length} matches`;
   }
 

--- a/ui/src/FindBarSymbol.tsx
+++ b/ui/src/FindBarSymbol.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { convertToAnnotationId } from './selectors/annotation'
+import { ScholarReaderContext } from "./state";
+import { BoundingBox } from "./types/api";
+
+interface FindBarProps {
+  mappingToBounds: Map<String, BoundingBox>;
+  matches: string[];
+}
+
+export class FindBarSymbol extends React.PureComponent<FindBarProps, {}> {
+  static contextType = ScholarReaderContext;
+  context!: React.ContextType<typeof ScholarReaderContext>;
+
+  componentWillUnmount() {
+    this.deselectSymbol();
+  }
+
+  wrapIndex(index: number, len: number) {
+    return (index % len + len) % len;
+  }
+
+  selectSymbol(id: string, boxId: string) {
+    this.context.setSelectedEntity(id, "symbol");
+    this.context.setSelectedAnnotationId(convertToAnnotationId(id));
+    this.context.setSelectedAnnotationSpanId(boxId);
+  }
+
+  deselectSymbol() {
+    this.context.setSelectedEntity(null, null);
+    this.context.setSelectedAnnotationId(null);
+    this.context.setSelectedAnnotationSpanId(null);
+  }
+
+  moveToNextSymbol(currId: string, movement: number, e: React.SyntheticEvent) {
+    const { matches, mappingToBounds } = this.props;
+		const currentMatch = matches.indexOf(currId);
+
+    const newEntityId = matches[
+      this.wrapIndex((currentMatch || 0) + movement, matches.length)
+    ];
+   
+    const newBoxId = mappingToBounds.has(newEntityId) ? mappingToBounds.get(newEntityId).id : '';
+    this.selectSymbol(newEntityId, newBoxId);
+		e.preventDefault();
+  }
+
+  closeFinder = (e: React.SyntheticEvent) => {
+    this.deselectSymbol();
+    e.preventDefault();
+  }
+
+  /*
+   * Based on 'PDFFindBar.updateResultsCount' in pdf.js:
+   * https://github.com/mozilla/pdf.js/blob/49f59eb627646ae9a6e166ee2e0ef2cac9390b4f/web/pdf_find_bar.js#L152
+   */
+  matchCountMessage(selectedSymbol: string) {
+    const MATCH_COUNT_LIMIT = 1000;
+
+    const { matches } = this.props;
+    if (selectedSymbol === null || matches === null) {
+      return null;
+    }
+
+    if ((matches.length || 0) > MATCH_COUNT_LIMIT) {
+      return `More than ${MATCH_COUNT_LIMIT} matches`;
+    }
+
+		const currentMatch = matches.indexOf(selectedSymbol) + 1;
+    return `${currentMatch} of ${matches.length} matches`;
+  }
+
+  render() {
+  return (
+    <ScholarReaderContext.Consumer>
+      {({ selectedEntityId }) => {
+        return (
+          <div className="find-bar">
+            <div className="find-bar__navigation">
+              <button
+                className="find-bar__navigation__previous"
+                onClick={(e) => this.moveToNextSymbol(selectedEntityId || '', -1, e)}
+              >
+                <span>Previous</span>
+              </button>
+              <button
+                className="find-bar__navigation__next"
+                onClick={(e) => this.moveToNextSymbol(selectedEntityId || '', 1, e)}
+              >
+                <span>Next</span>
+              </button>
+            </div>
+            <div className="find-bar__message">
+              <span className="find-bar__message__span">
+                {selectedEntityId && this.matchCountMessage(selectedEntityId)}
+              </span>
+            </div>
+            <div className="find-bar__close" onClick={this.closeFinder}>X</div>
+          </div>
+        )}}
+      </ScholarReaderContext.Consumer>
+    )
+  }
+
+  queryElement: HTMLInputElement | null = null;
+}
+
+export default FindBarSymbol;

--- a/ui/src/PageOverlay.tsx
+++ b/ui/src/PageOverlay.tsx
@@ -12,6 +12,7 @@ import { UserAnnotationLayer } from "./UserAnnotationLayer";
 interface PageProps {
   pageNumber: number;
   view: PDFPageView;
+  highlightedSymbols: string[];
 }
 
 /**
@@ -67,25 +68,6 @@ class PageOverlay extends React.PureComponent<PageProps, {}> {
       this._element.classList.remove("user-annotations-enabled");
     }
 
-    /*
-     * Assemble a list of symbols that should highlighted based on the currently selected entity.
-     */
-    const highlightedSymbols: string[] = [];
-    if (
-      this.context.symbols !== null &&
-      this.context.mathMls !== null &&
-      this.context.selectedEntityType === "symbol" &&
-      this.context.selectedEntityId !== null
-    ) {
-      highlightedSymbols.push(
-        ...selectors.matchingSymbols(
-          this.context.selectedEntityId,
-          this.context.symbols,
-          this.context.mathMls
-        )
-      );
-    }
-
     const pageDimensions = getPageViewDimensions(this.props.view);
     return ReactDOM.createPortal(
       <ScholarReaderContext.Consumer>
@@ -133,7 +115,7 @@ class PageOverlay extends React.PureComponent<PageProps, {}> {
                         showHint={annotationsShowing}
                         boundingBoxes={boundingBoxes}
                         symbol={symbol}
-                        highlight={highlightedSymbols.indexOf(sId) !== -1}
+                        highlight={this.props.highlightedSymbols.indexOf(sId) !== -1}
                       />
                     ) : null;
                   })

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -12,7 +12,7 @@ import {
   createStateSliceFromArray,
   defaultState,
   DrawerState,
-	FindBarState,
+  FindBarState,
   MathMls,
   Pages,
   PaperId,
@@ -85,9 +85,9 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
 
       setDrawerState: this.setDrawerState.bind(this),
       scrollSymbolIntoView: this.scrollSymbolIntoView.bind(this),
-
-			setFindBarState: this.setFindBarState.bind(this),	
-
+      
+      setFindBarState: this.setFindBarState.bind(this),	
+      
       setUserAnnotationsEnabled: this.setUserAnnotationsEnabled.bind(this),
       setUserAnnotationType: this.setUserAnnotationType.bind(this),
       addUserAnnotation: this.addUserAnnotation.bind(this),
@@ -167,7 +167,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
 		if (type === 'symbol') {
 		  this.setFindBarState('symbol');
 		} else if (this.state.findBarState === 'symbol') {
-			this.setFindBarState('hidden');
+      this.setFindBarState('hidden');
 		}
   }
 
@@ -329,7 +329,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
      * https://github.com/mozilla/pdf.js/blob/49f59eb627646ae9a6e166ee2e0ef2cac9390b4f/web/app.js#L2503
      */
     if ((event.ctrlKey || event.metaKey) && event.keyCode === 70) {
-			this.setFindBarState("string");
+      this.setFindBarState("string");
       event.preventDefault();
     }
   }
@@ -541,14 +541,14 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
            */}
           {this.state.findBarState !== 'hidden' && window.PDFViewerApplication !== undefined && elFindBarContainer
             ? createPortal(
-								this.state.findBarState === 'symbol' ? 
+                this.state.findBarState === 'symbol' ? 
                 <FindBarSymbol
                   mappingToBounds={highlightedSymbols}
                   matches={[...highlightedSymbols.keys()]}
                   /> : 
-								<FindBarString 
-							    setMode={this.state.setFindBarState}
-								/>, 
+                <FindBarString 
+                  setMode={this.state.setFindBarState}
+                />, 
                 elFindBarContainer)
             : null}
         </>

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -466,7 +466,7 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         return pgNumberDiff === 0 ? s1[1].top - s2[1].top : pgNumberDiff;
       })
       .map(([id, boundingBox]) => {
-        highlightedSymbols.set(id, bounding)  
+        highlightedSymbols.set(id, boundingBox)  
       })
     }
     return (

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -462,8 +462,8 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
         return [id, symbolBox]
       })
       .sort((s1, s2) => {
-        const pg = s1[1].page - s2[1].page;
-        return pg === 0 ? s1[1].top - s2[1].top : pg;
+        const pgNumberDiff = s1[1].page - s2[1].page;
+        return pgNumberDiff === 0 ? s1[1].top - s2[1].top : pgNumberDiff;
       })
       .map(([id, bounding]) => {
         highlightedSymbols.set(id, bounding)  

--- a/ui/src/SymbolAnnotation.tsx
+++ b/ui/src/SymbolAnnotation.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import React from "react";
 import Annotation from "./Annotation";
+import { convertToAnnotationId } from './selectors/annotation'
 import { ScholarReaderContext } from "./state";
 import { BoundingBox, Symbol } from "./types/api";
 
@@ -21,11 +22,8 @@ export class SymbolAnnotation extends React.PureComponent<
     return (
       <div hidden={this.props.symbol.parent !== null}>
         <Annotation
-          id={`symbol-${this.props.symbol.id}-annotation`}
-          className={classNames({ 
-            "annotation-hint": this.props.showHint, 
-            "annotation-is-the-selected-symbol": this.context.selectedEntityId === this.props.symbol.id,
-          })}
+          id={convertToAnnotationId(this.props.symbol.id)}
+          className={classNames({ "annotation-hint": this.props.showHint })}
           source={this.props.symbol.source}
           boundingBoxes={this.props.boundingBoxes}
           /* tooltipContent={<SymbolTooltipBody symbol={this.props.symbol} />} */

--- a/ui/src/SymbolAnnotation.tsx
+++ b/ui/src/SymbolAnnotation.tsx
@@ -22,7 +22,10 @@ export class SymbolAnnotation extends React.PureComponent<
       <div hidden={this.props.symbol.parent !== null}>
         <Annotation
           id={`symbol-${this.props.symbol.id}-annotation`}
-          className={classNames({ "annotation-hint": this.props.showHint })}
+          className={classNames({ 
+            "annotation-hint": this.props.showHint, 
+            "annotation-is-the-selected-symbol": this.context.selectedEntityId === this.props.symbol.id,
+          })}
           source={this.props.symbol.source}
           boundingBoxes={this.props.boundingBoxes}
           /* tooltipContent={<SymbolTooltipBody symbol={this.props.symbol} />} */

--- a/ui/src/selectors/annotation.ts
+++ b/ui/src/selectors/annotation.ts
@@ -29,3 +29,10 @@ export function divDimensionStyles(
 export function boundingBoxString(boundingBox: BoundingBox) {
   return `${boundingBox.page}-L${boundingBox.left}-T${boundingBox.top}-W${boundingBox.width}-H${boundingBox.height}`;
 }
+
+/**
+ * Convert a *Symbols* entityId to it's AnnotationId
+ */
+export function convertToAnnotationId(id: String) {
+  return `symbol-${id}-annotation`;
+}

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -194,8 +194,8 @@ export const defaultState: State = {
   drawerState: "closed",
   setDrawerState: () => {},
   scrollSymbolIntoView: () => {},
-
-	setFindBarState: () => {},
+  
+  setFindBarState: () => {},
   findBarState: "hidden",
 
   userAnnotationsEnabled: false,

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -73,6 +73,12 @@ export interface State {
   setDrawerState(open: DrawerState): void;
   scrollSymbolIntoView(): void;
 
+	/*
+	 * Find Bar interactions
+	 */
+	findBarState: FindBarState;
+	setFindBarState(state: FindBarState): void;
+
   /*
    * User annotation layer
    */
@@ -148,6 +154,7 @@ export interface PaperId {
 }
 
 export type DrawerState = "open" | "closed";
+export type FindBarState = "hidden" | "symbol" | "string";
 
 export const defaultState: State = {
   paperId: undefined,
@@ -187,6 +194,9 @@ export const defaultState: State = {
   drawerState: "closed",
   setDrawerState: () => {},
   scrollSymbolIntoView: () => {},
+
+	setFindBarState: () => {},
+  findBarState: "hidden",
 
   userAnnotationsEnabled: false,
   setUserAnnotationsEnabled: () => {},

--- a/ui/src/state.ts
+++ b/ui/src/state.ts
@@ -59,7 +59,6 @@ export interface State {
   selectedEntityType: SelectableEntityType;
   selectedEntityId: string | null;
   setSelectedEntity(id: string | null, type: SelectableEntityType): void;
-  selectAnnotationForEntity(id: string, type: SelectableEntityType): void;
 
   /*
    * Jumping to content within paper
@@ -181,7 +180,6 @@ export const defaultState: State = {
   selectedEntityType: null,
   selectedEntityId: null,
   setSelectedEntity: () => {},
-  selectAnnotationForEntity: () => {},
 
   paperJumpRequest: null,
   requestJumpToPaper: () => {},

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -42,7 +42,7 @@
   /** 
    * Give the selected annotation extra highlighting
    */
-  &.annotation-is-the-selected-symbol {
+  &.selected {
     background-color: red !important;
   }
 

--- a/ui/src/style/annotation.less
+++ b/ui/src/style/annotation.less
@@ -39,6 +39,12 @@
     background-color: @highlight-color;
     opacity: @highlight-opacity;
   }
+  /** 
+   * Give the selected annotation extra highlighting
+   */
+  &.annotation-is-the-selected-symbol {
+    background-color: red !important;
+  }
 
   &.sentence-highlight {
     background-color: rgba(255, 255, 0, 0.3);

--- a/ui/src/style/find-bar.less
+++ b/ui/src/style/find-bar.less
@@ -12,3 +12,8 @@
     padding-left: @padding;
   }
 }
+
+.find-bar__close {
+  cursor: pointer;
+  font-weight: bold;
+}


### PR DESCRIPTION
Semi-working implementation of symbol search.
**TODO:**
- Fix typescript errors
- Remove hack to clear search query on close

**Search for a symbol:**
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/22308211/79807376-8d88d080-831f-11ea-802a-14f84c3f2aa0.gif)
**Interrupt a symbol search with text and vice versa:**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/22308211/79807466-c759d700-831f-11ea-92eb-8e8eb4c7fcce.gif)
