### PR TITLE
"View PDF" button on citation tooltip

### DIFF
--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -47,8 +47,12 @@ async function getPaper(s2Id: string): Promise<Paper | undefined> {
     console.error("Failed to fetch data from Semantic Scholar API", err);
     return;
   }
+
   if (isS2ApiResponseSuccess(response)) {
     const data = response.data as S2Api;
+    if (data.paper === undefined) {
+      return;
+    }
     var year;
     if (data.paper.year.text === undefined) {
       year = null;
@@ -58,7 +62,7 @@ async function getPaper(s2Id: string): Promise<Paper | undefined> {
     return {
       s2Id,
       title: data.paper.title.text,
-      authors: data.paper.authors.map(a => ({
+      authors: data.paper.authors[0].map(a => ({
         id: a.ids,
         name: a.name,
       })),

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -4,7 +4,7 @@ import { isS2ApiResponseSuccess, S2ApiPaper } from "./types/s2-api";
 /**
  * Base URL for requests to Semantic Scholar API.
  */
-const SEMANTIC_SCHOLAR_API_URL = "http://api.semanticscholar.org/v1";
+const SEMANTIC_SCHOLAR_API_URL = "https://www.semanticscholar.org/api/1";
 
 interface Author {
   id: string;

--- a/api/src/s2-api.ts
+++ b/api/src/s2-api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { isS2ApiResponseSuccess, S2Api } from "./types/s2-api";
+import { isS2ApiResponseSuccess, S2ApiPaperResponse } from "./types/s2-api";
 
 /**
  * Base URL for requests to Semantic Scholar API.
@@ -21,6 +21,7 @@ interface Paper {
   citationVelocity: number;
   influentialCitationCount: number;
   primaryPaperLink: string;
+  paperLinkType: string;
 }
 
 /**
@@ -49,7 +50,7 @@ async function getPaper(s2Id: string): Promise<Paper | undefined> {
   }
 
   if (isS2ApiResponseSuccess(response)) {
-    const data = response.data as S2Api;
+    const data = response.data as S2ApiPaperResponse;
     if (data.paper === undefined) {
       return;
     }
@@ -72,6 +73,7 @@ async function getPaper(s2Id: string): Promise<Paper | undefined> {
       citationVelocity: data.paper.citationStats.citationVelocity || 0,
       influentialCitationCount: data.paper.citationStats.numKeyCitations || 0,
       primaryPaperLink: data.paper.primaryPaperLink.url,
+      paperLinkType: data.paper.primaryPaperLink.linkType,
     };
   }
 }

--- a/api/src/types/s2-api.ts
+++ b/api/src/types/s2-api.ts
@@ -21,7 +21,7 @@ interface S2ApiPaper {
   id: string;
   title: S2ApiTitle;
   paperAbstract: S2ApiAbstract;
-  authors: S2ApiAuthor[];
+  authors: S2ApiAuthor[][];
   year: S2ApiYear;
   venue: S2ApiVenue;
   primaryPaperLink: S2ApiPaperLink;

--- a/api/src/types/s2-api.ts
+++ b/api/src/types/s2-api.ts
@@ -13,7 +13,7 @@ interface S2ApiSuccess {
   status: 200;
 }
 
-export interface S2Api {
+export interface S2ApiPaperResponse {
   paper: S2ApiPaper;
 }
 
@@ -47,6 +47,7 @@ interface S2ApiVenue {
 
 interface S2ApiPaperLink {
   url: string;
+  linkType: string;
 }
 
 interface S2ApiDoi {

--- a/api/src/types/s2-api.ts
+++ b/api/src/types/s2-api.ts
@@ -13,21 +13,52 @@ interface S2ApiSuccess {
   status: 200;
 }
 
-export interface S2ApiPaper {
-  abstract: string;
-  arxivId: string | null;
+export interface S2Api {
+  paper: S2ApiPaper;
+}
+
+interface S2ApiPaper {
+  id: string;
+  title: S2ApiTitle;
+  paperAbstract: S2ApiAbstract;
   authors: S2ApiAuthor[];
-  doi: string;
-  title: string;
+  year: S2ApiYear;
+  venue: S2ApiVenue;
+  primaryPaperLink: S2ApiPaperLink;
+  doiInfo: S2ApiDoi;
+  citationStats: S2ApiCitationStats;
+}
+
+export interface S2ApiTitle {
+  text: string;
+}
+
+interface S2ApiAbstract {
+  text: string;
+}
+
+interface S2ApiYear {
+  text: string;
+}
+
+interface S2ApiVenue {
+  text: string;
+}
+
+interface S2ApiPaperLink {
   url: string;
-  venue: string;
-  year: string;
-  influentialCitationCount?: number;
-  citationVelocity?: number;
+}
+
+interface S2ApiDoi {
+  doi: string;
+}
+
+interface S2ApiCitationStats {
+  citationVelocity: number;
+  numKeyCitations: number;
 }
 
 interface S2ApiAuthor {
-  authorId: string;
+  ids: string;
   name: string;
-  url: string;
 }

--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -17,7 +17,7 @@ export class Citation extends React.PureComponent<CitationProperties> {
             return (
               <div>
                 <p>Sorry, we currently don't have any linked information for this paper yet.</p>
-                <p>Let us know what went wrong by clicking on the icon below, so we could provide 
+                <p>Let us know what went wrong by clicking on the icon below, so we could provide
                 you with better reading experience in the future!</p>
               </div>
             )
@@ -43,6 +43,11 @@ export class Citation extends React.PureComponent<CitationProperties> {
                     >
                       (see more)
                     </span>
+                  </div>
+                ) : null}
+                {paper.primaryPaperLink !== null ? (
+                  <div className="citation__utils">
+                    <a href={paper.primaryPaperLink} target="_blank" rel="noopener noreferrer">View PDF</a>
                   </div>
                 ) : null}
               </div>

--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ScholarReaderContext } from "./state";
 import { Citation as CitationObject } from "./types/api";
-import { truncateText } from "./ui-utils";
+import { truncateText, getLinkText } from "./ui-utils";
 
 interface CitationProperties {
   citation: CitationObject;
@@ -13,6 +13,7 @@ export class Citation extends React.PureComponent<CitationProperties> {
       <ScholarReaderContext.Consumer>
         {({ papers, setJumpPaperId, setSelectedCitation }) => {
           const paper = papers[this.props.citation.paper];
+          console.log(paper.paperLinkType);
           if (paper === undefined) {
             return (
               <div>
@@ -47,7 +48,7 @@ export class Citation extends React.PureComponent<CitationProperties> {
                 ) : null}
                 {paper.primaryPaperLink !== null ? (
                   <div className="citation__utils">
-                    <a href={paper.primaryPaperLink} target="_blank" rel="noopener noreferrer">View PDF</a>
+                    <a href={paper.primaryPaperLink} target="_blank" rel="noopener noreferrer"><button className="citation__view__pdf">{getLinkText(paper.paperLinkType)}</button></a>
                   </div>
                 ) : null}
               </div>

--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -25,7 +25,6 @@ export class Citation extends React.PureComponent<CitationProperties> {
             return (
               <div className="citation">
                 <p className="title">{paper.title}</p>
-                {console.log(paper.authors)}
                 {paper.authors.length > 0 && (
                   <>
                     by {paper.authors[0].name}{" "}

--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -13,7 +13,6 @@ export class Citation extends React.PureComponent<CitationProperties> {
       <ScholarReaderContext.Consumer>
         {({ papers, setJumpPaperId, setSelectedCitation }) => {
           const paper = papers[this.props.citation.paper];
-          console.log(paper.paperLinkType);
           if (paper === undefined) {
             return (
               <div>

--- a/ui/src/Citation.tsx
+++ b/ui/src/Citation.tsx
@@ -25,6 +25,7 @@ export class Citation extends React.PureComponent<CitationProperties> {
             return (
               <div className="citation">
                 <p className="title">{paper.title}</p>
+                {console.log(paper.authors)}
                 {paper.authors.length > 0 && (
                   <>
                     by {paper.authors[0].name}{" "}

--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -101,7 +101,7 @@ export class PaperSummary extends React.PureComponent<
           const hasMetrics = paper.citationVelocity !== 0 || paper.influentialCitationCount !== 0;
           const truncatedAbstract = paper.abstract ? truncateText(paper.abstract, 300) : null;
           const inLibrary = userLibrary ? userLibrary.paperIds.includes(this.props.paperId) : false;
-          const summaryUrl = `https://www.semanticscholar.org/paper/{paper.s2Id}`
+          const pdpUrl = `https://www.semanticscholar.org/paper/{paper.s2Id}`
           return (
             <div
               ref={ref => {

--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -10,13 +10,13 @@ import InfluentialCitationIcon from "./icon/InfluentialCitationIcon";
 import S2Link from "./S2Link";
 import { ScholarReaderContext } from "./state";
 import { truncateText } from "./ui-utils";
-import {userLibraryUrl} from "./s2-url";
-import {UserLibrary} from "./types/api";
+import { userLibraryUrl } from "./s2-url";
+import { UserLibrary } from "./types/api";
 
 function warnOfUnimplementedActionAndTrack(actionType: string) {
   alert("Sorry, that feature isn't implemented yet. Clicking it tells us " +
-        "you're interested in the feature, increasing the likelihood that " +
-        "it'll be implemented!");
+    "you're interested in the feature, increasing the likelihood that " +
+    "it'll be implemented!");
   if (window.heap) {
     window.heap.track(
       "Click on Unimplemented Action",
@@ -32,8 +32,8 @@ function goToLibrary() {
 function trackLibrarySave() {
   if (window.heap) {
     window.heap.track(
-        "Save to Library",
-        { actionType: 'save' }
+      "Save to Library",
+      { actionType: 'save' }
     );
   }
 }
@@ -50,7 +50,7 @@ interface PaperSummaryState {
 export class PaperSummary extends React.PureComponent<
   PaperSummaryProps,
   PaperSummaryState
-> {
+  > {
 
   static contextType = ScholarReaderContext;
   context!: React.ContextType<typeof ScholarReaderContext>;
@@ -67,9 +67,9 @@ export class PaperSummary extends React.PureComponent<
   renderLibraryButton(label: string, onClick: () => void) {
     return (
       <Button
-          startIcon={<SaveIcon />}
-          className="paper-summary__action"
-          onClick={onClick}>
+        startIcon={<SaveIcon />}
+        className="paper-summary__action"
+        onClick={onClick}>
         {label}
       </Button>
     )
@@ -101,6 +101,7 @@ export class PaperSummary extends React.PureComponent<
           const hasMetrics = paper.citationVelocity !== 0 || paper.influentialCitationCount !== 0;
           const truncatedAbstract = paper.abstract ? truncateText(paper.abstract, 300) : null;
           const inLibrary = userLibrary ? userLibrary.paperIds.includes(this.props.paperId) : false;
+          const summaryUrl = `https://www.semanticscholar.org/paper/{paper.Id}`
           return (
             <div
               ref={ref => {
@@ -115,7 +116,7 @@ export class PaperSummary extends React.PureComponent<
             >
               <div className="paper-summary__section">
                 <p className="paper-summary__title">
-                  <S2Link url={paper.url}>{paper.title}</S2Link>
+                  <S2Link url={summaryUrl}>{paper.title}</S2Link>
                 </p>
                 <p>
                   {paper.authors.length > 0 && (
@@ -130,71 +131,71 @@ export class PaperSummary extends React.PureComponent<
                 <div className="paper-summary__section">
                   <p className="paper-summary__abstract">
                     {this.state.showFullAbstract ||
-                    truncatedAbstract === paper.abstract ? (
-                      paper.abstract
-                    ) : (
-                      <>
-                        {truncatedAbstract}
-                        <span
-                          className="paper-summary__abstract__show-more-label"
-                          onClick={() => {
-                            this.setState({ showFullAbstract: true });
-                          }}
-                        >
-                          (show more)
+                      truncatedAbstract === paper.abstract ? (
+                        paper.abstract
+                      ) : (
+                        <>
+                          {truncatedAbstract}
+                          <span
+                            className="paper-summary__abstract__show-more-label"
+                            onClick={() => {
+                              this.setState({ showFullAbstract: true });
+                            }}
+                          >
+                            (show more)
                         </span>
-                      </>
-                    )}
+                        </>
+                      )}
                   </p>
                 </div>
               )}
               <div className="paper-summary__metrics-and-actions">
-                  {hasMetrics ? (
-                    <div className="paper-summary__metrics">
-                      {paper.influentialCitationCount > 0 ? (
-                        <Tooltip
-                          placement="bottom-start"
-                          title={
-                            <>
-                              <strong>{paper.influentialCitationCount} influential
+                {hasMetrics ? (
+                  <div className="paper-summary__metrics">
+                    {paper.influentialCitationCount > 0 ? (
+                      <Tooltip
+                        placement="bottom-start"
+                        title={
+                          <>
+                            <strong>{paper.influentialCitationCount} influential
                               citation{paper.influentialCitationCount !== 1 ? 's' : ''}</strong>
-                            </>
-                          }
-                        >
-                          <div className="paper-summary__metrics__metric">
-                            <InfluentialCitationIcon width="12" height="12" />
-                            {paper.influentialCitationCount}
-                          </div>
-                        </Tooltip>
-                      ): null}
-                      {paper.citationVelocity > 0 ? (
-                        <Tooltip
-                          placement="bottom-start"
-                          title={
-                            <>
-                              <strong>Averaging {paper.citationVelocity} citation{paper.citationVelocity !== 1 ? 's ' : ' '}
+                          </>
+                        }
+                      >
+                        <div className="paper-summary__metrics__metric">
+                          <InfluentialCitationIcon width="12" height="12" />
+                          {paper.influentialCitationCount}
+                        </div>
+                      </Tooltip>
+                    ) : null}
+                    {paper.citationVelocity > 0 ? (
+                      <Tooltip
+                        placement="bottom-start"
+                        title={
+                          <>
+                            <strong>Averaging {paper.citationVelocity} citation{paper.citationVelocity !== 1 ? 's ' : ' '}
                               per year</strong>
-                            </>
-                          }
-                        >
-                          <div className="paper-summary__metrics__metric">
-                            <ChartIcon width="15" height="15" />
-                            {paper.citationVelocity}
-                          </div>
-                        </Tooltip>
-                      ): null}
-                    </div>
-                  ) : null}
-                  <Button
-                    startIcon={<CiteIcon />}
-                    className="paper-summary__action"
-                    onClick={() => warnOfUnimplementedActionAndTrack("cite")}
-                  >
-                    Cite
+                          </>
+                        }
+                      >
+                        <div className="paper-summary__metrics__metric">
+                          <ChartIcon width="15" height="15" />
+                          {paper.citationVelocity}
+                        </div>
+                      </Tooltip>
+                    ) : null}
+                  </div>
+                ) : null}
+                <Button
+                  startIcon={<CiteIcon />}
+                  className="paper-summary__action"
+                  onClick={() => warnOfUnimplementedActionAndTrack("cite")}
+                >
+                  Cite
                   </Button>
-                  {inLibrary ? this.renderLibraryButton('In Your Library', () => goToLibrary())
-                      : this.renderLibraryButton('Save To Library', () => this.saveToLibrary(userLibrary, addToLibrary, paper.title))
-                  }
+                {inLibrary ? this.renderLibraryButton('In Your Library', () => goToLibrary())
+                  : this.renderLibraryButton('Save To Library', () => this.saveToLibrary(userLibrary, addToLibrary, paper.title))
+                }
               </div>
               <FavoriteButton
                 favoritableId={{

--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -116,7 +116,7 @@ export class PaperSummary extends React.PureComponent<
             >
               <div className="paper-summary__section">
                 <p className="paper-summary__title">
-                  <S2Link url={summaryUrl}>{paper.title}</S2Link>
+                  <S2Link url={pdpUrl}>{paper.title}</S2Link>
                 </p>
                 <p>
                   {paper.authors.length > 0 && (

--- a/ui/src/PaperSummary.tsx
+++ b/ui/src/PaperSummary.tsx
@@ -101,7 +101,7 @@ export class PaperSummary extends React.PureComponent<
           const hasMetrics = paper.citationVelocity !== 0 || paper.influentialCitationCount !== 0;
           const truncatedAbstract = paper.abstract ? truncateText(paper.abstract, 300) : null;
           const inLibrary = userLibrary ? userLibrary.paperIds.includes(this.props.paperId) : false;
-          const summaryUrl = `https://www.semanticscholar.org/paper/{paper.Id}`
+          const summaryUrl = `https://www.semanticscholar.org/paper/{paper.s2Id}`
           return (
             <div
               ref={ref => {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -448,8 +448,8 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
           // Add 50px padding to make the symbol close to the drawer but not hidden by it.
           pdfViewer.container.scrollLeft += Math.max(
             relativeSymbolRightPosition -
-              viewableViewportWidth +
-              SYMBOL_VIEW_PADDING,
+            viewableViewportWidth +
+            SYMBOL_VIEW_PADDING,
             0
           );
         }
@@ -486,15 +486,15 @@ class ScholarReader extends React.PureComponent<ScholarReaderProps, State> {
           <Drawer />
           {elFeedbackContainer
             ? createPortal(
-                <FeedbackButton variant="toolbar" />,
-                elFeedbackContainer
-              )
+              <FeedbackButton variant="toolbar" />,
+              elFeedbackContainer
+            )
             : null}
           {this.state.userAnnotationsEnabled && elUserAnnotationTypeContainer
             ? createPortal(
-                <UserAnnotationTypeSelect />,
-                elUserAnnotationTypeContainer
-              )
+              <UserAnnotationTypeSelect />,
+              elUserAnnotationTypeContainer
+            )
             : null}
         </>
       </ScholarReaderContext.Provider>

--- a/ui/src/style/citation.less
+++ b/ui/src/style/citation.less
@@ -34,3 +34,32 @@
     cursor: pointer;
   }
 }
+
+/**
+ * Citation utilities.
+ */
+.citation__utils {
+  padding-top: @padding;
+}
+
+/**
+ * button for viewing paper in PDF
+ */
+.citation__view__pdf {
+  background: @button-background-color;
+  color: @white;
+  font-size: @button-font-size;
+  line-height: normal;
+  padding: @button-padding-top @button-padding-side;
+  border: @border-width solid transparent;
+  border-radius: @button-radius;
+  justify-content: center;
+  margin: @button-margin;
+  font-weight: @button-font-weight;
+  font-family: Roboto;
+
+  &:hover {
+    cursor: pointer;
+    background: @button-hover-color;
+  }
+}

--- a/ui/src/style/citation.less
+++ b/ui/src/style/citation.less
@@ -46,20 +46,20 @@
  * button for viewing paper in PDF
  */
 .citation__view__pdf {
-  background: @button-background-color;
+  background: @s2-primary-action-background-color;
   color: @white;
-  font-size: @button-font-size;
+  font-size: @s2-primary-action-font-size;
   line-height: normal;
-  padding: @button-padding-top @button-padding-side;
+  padding: @s2-primary-action-padding-top @s2-primary-action-padding-side;
   border: @border-width solid transparent;
-  border-radius: @button-radius;
+  border-radius: @s2-primary-action-radius;
   justify-content: center;
-  margin: @button-margin;
-  font-weight: @button-font-weight;
+  margin: @s2-primary-action-margin;
+  font-weight: @s2-primary-action-font-weight;
   font-family: Roboto;
 
   &:hover {
     cursor: pointer;
-    background: @button-hover-color;
+    background: @s2-primary-action-hover-color;
   }
 }

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -17,8 +17,8 @@
 @equation-user-annotation-color: #e82;
 @symbol-user-annotation-color: #f5f;
 
-@button-background-color: #1857b6;
-@button-hover-color: #1f6de2;
+@s2-primary-action-background-color: #1857b6;
+@s2-primary-action-hover-color: #1f6de2;
 
 /**
  * S2 COLORS
@@ -61,8 +61,8 @@
  */
 @large: 1.6rem;
 @medium: 1.4rem;
-@button-font-size: 14px;
-@button-font-weight: 400;
+@s2-primary-action-font-size: 14px;
+@s2-primary-action-font-weight: 400;
 
 /**
  * SPACE
@@ -72,12 +72,12 @@
 @tooltip-content-vertical-padding: @medium * 0.5;
 
 /**
- * BUTTON
+ * S2 PRIMARY ACTION
  */
- @button-padding-top: 5px;
- @button-padding-side: 10px;
- @button-radius: 3px;
- @button-margin: 0;
+ @s2-primary-action-padding-top: 5px;
+ @S2-primary-action-padding-side: 10px;
+ @s2-primary-action-radius: 3px;
+ @s2-primary-action-margin: 0;
 
 /**
  * ELEMENT DIMENSIONS

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -75,7 +75,7 @@
  * S2 PRIMARY ACTION
  */
  @s2-primary-action-padding-top: 5px;
- @S2-primary-action-padding-side: 10px;
+ @s2-primary-action-padding-side: 10px;
  @s2-primary-action-radius: 3px;
  @s2-primary-action-margin: 0;
 

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -17,6 +17,9 @@
 @equation-user-annotation-color: #e82;
 @symbol-user-annotation-color: #f5f;
 
+@button-background-color: #1857b6;
+@button-hover-color: #1f6de2;
+
 /**
  * S2 COLORS
  */
@@ -37,12 +40,14 @@
 @highlight-hover-background: rgb(0, 0, 255);
 @highlight-hitbox-padding: 0.1em;
 @highlight-matching-entity-color: rgba(70, 130, 180, 0.3);
+
 /**
  * TEXT STYLING
  */
 @underline-offset: 5px;
 @underline-width: 1px;
 @underline-color: #333;
+
 /**
  * BORDERS
  */
@@ -56,6 +61,8 @@
  */
 @large: 1.6rem;
 @medium: 1.4rem;
+@button-font-size: 14px;
+@button-font-weight: 400;
 
 /**
  * SPACE
@@ -63,6 +70,14 @@
 @padding: @medium;
 @margin: @medium;
 @tooltip-content-vertical-padding: @medium * 0.5;
+
+/**
+ * BUTTON
+ */
+ @button-padding-top: 5px;
+ @button-padding-side: 10px;
+ @button-radius: 3px;
+ @button-margin: 0;
 
 /**
  * ELEMENT DIMENSIONS

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -50,6 +50,7 @@ export interface Paper {
   citationVelocity: number;
   influentialCitationCount: number;
   primaryPaperLink: string;
+  paperLinkType: string;
 }
 
 export interface Citation {

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -45,11 +45,11 @@ export interface Paper {
   title: string;
   authors: Author[];
   abstract: string | null;
-  url: string;
   venue: string | null;
   year: number | null;
   citationVelocity: number;
   influentialCitationCount: number;
+  primaryPaperLink: string;
 }
 
 export interface Citation {

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -73,46 +73,35 @@ export function truncateText(text: string, limit: number, withEllipsis: boolean 
 export function getLinkText(input: string): string {
 
   var linkText: string = "";
+  const linkTextLengthLimit = 17;
 
-  if (input.length > 17) {
-    linkText = "View Via Publisher";
-    return linkText;
+  if (input.length > linkTextLengthLimit) {
+    return "View Via Publisher"
   }
 
   switch (input) {
     case "acm":
-      linkText = "View On ACM";
-      break;
+      return "View On ACM"
     case "anansi":
-      linkText = "View Paper";
-      break;
+      return "View Paper"
     case "arxiv":
-      linkText = "View On ArXiv";
-      break;
+      return "View on ArXiv"
     case "dblp":
-      linkText = "View Paper";
-      break;
+      return "View Paper"
     case "doi":
-      linkText = "View Via Publisher";
-      break;
+      return "View Via Publisher"
     case "educause":
-      linkText = "View On Educause";
-      break;
+      return "View On Educause"
     case "ieee":
-      linkText = "View On IEEE";
-      break;
+      return "View on IEEE"
     case "institutional":
-      linkText = "Check Your Institution";
-      break;
+      return "Check Your Institution"
     case "medline":
-      linkText = "View On PubMed";
-      break;
+      return "View On PubMed"
     case "s2":
-      linkText = "View Paper";
-      break;
+      return "View Paper"
     case "wiley":
-      linkText = "View Via Publisher";
-      break;
+      return "View Via Publisher"
     default:
       linkText = "View On " + input;
   }

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -50,7 +50,7 @@ export function truncateText(text: string, limit: number, withEllipsis: boolean 
   if (text.length > limit) {
     while (
       limit > 1 &&
-      (!PATTERN_WORD_CHAR.test(text[limit-1]) || !PATTERN_NON_WORD_CHAR.test(text[limit]))
+      (!PATTERN_WORD_CHAR.test(text[limit - 1]) || !PATTERN_NON_WORD_CHAR.test(text[limit]))
     ) {
       limit -= 1;
     }
@@ -63,4 +63,63 @@ export function truncateText(text: string, limit: number, withEllipsis: boolean 
   } else {
     return text;
   }
+}
+
+/**
+ * Get the correct display name for certain publishers.
+ * 
+ * @param {string} the type of primaryPaperLInk
+ */
+export function getLinkText(input: string): string {
+
+  var linkText: string = "";
+
+  if (input.length > 17) {
+    linkText = "View Via Publisher";
+    return linkText;
+  }
+
+  switch (input) {
+    case "acm":
+      linkText = "View On ACM";
+      break;
+    case "anansi":
+      linkText = "View Paper";
+      break;
+    case "arxiv":
+      linkText = "View On ArXiv";
+      break;
+    case "dblp":
+      linkText = "View Paper";
+      break;
+    case "doi":
+      linkText = "View Via Publisher";
+      break;
+    case "educause":
+      linkText = "View On Educause";
+      break;
+    case "ieee":
+      linkText = "View On IEEE";
+      break;
+    case "institutional":
+      linkText = "Check Your Institution";
+      break;
+    case "medline":
+      linkText = "View On PubMed";
+      break;
+    case "s2":
+      linkText = "View Paper";
+      break;
+    case "wiley":
+      linkText = "View Via Publisher";
+      break;
+    default:
+      linkText = "View On " + input;
+  }
+
+  if (input === "publisher") {
+    linkText = "View via Publisher"
+  }
+
+  return linkText;
 }

--- a/ui/src/ui-utils.ts
+++ b/ui/src/ui-utils.ts
@@ -67,19 +67,18 @@ export function truncateText(text: string, limit: number, withEllipsis: boolean 
 
 /**
  * Get the correct display name for certain publishers.
- * 
  * @param {string} the type of primaryPaperLInk
  */
-export function getLinkText(input: string): string {
+export function getLinkText(linkType: string): string {
 
   var linkText: string = "";
   const linkTextLengthLimit = 17;
 
-  if (input.length > linkTextLengthLimit) {
+  if (linkType.length > linkTextLengthLimit) {
     return "View Via Publisher"
   }
 
-  switch (input) {
+  switch (linkType) {
     case "acm":
       return "View On ACM"
     case "anansi":
@@ -103,10 +102,10 @@ export function getLinkText(input: string): string {
     case "wiley":
       return "View Via Publisher"
     default:
-      linkText = "View On " + input;
+      linkText = "View On " + linkType;
   }
 
-  if (input === "publisher") {
+  if (linkType === "publisher") {
     linkText = "View via Publisher"
   }
 


### PR DESCRIPTION
This is a working version of the feature for issue #90 and it has two parts:

1. API
On the API side, we switched to a new API, because the previous API we were using doesn't contain a link to the PDF of the cited paper (or a link to the website where the paper is published in the case that the paper isn't available to view for free), this link is stored in the property `primaryPaperLink`.
Edits in `s2-api.ts` were made to match with the JSON structure provided by the new API, it's more nested (hence all the interfaces created). The purpose is to make the data structure consistent for the UI, so minimum changes were needed on the UI side for this new API to work for our needs.

2. UI
As detailed in #90 ,now users could access the PDF of the cited paper (or a website where they could access the paper) directly from the citation tooltip, under the paper abstract section.
![image](https://user-images.githubusercontent.com/52334652/80033763-22b3d280-84a2-11ea-8949-5b4be16d73d0.png)
When user click on `View PDF`, the link opens on a new tab. The `<a>` tag uses `rel="noopener noreferrer"`, this is suggested by node.js when compiling for security purposes, more information about these tags could be find [here](https://developers.google.com/web/tools/lighthouse/audits/noopener).

3. More work
I could imagine a better version of this might include the styling of the button, e.g. padding (especially top padding), whether we want to make it a "button" button so it's more consistent with the paper detail page on semantic scholar ([example](https://www.semanticscholar.org/paper/Multimodal-Deep-Learning-Ngiam-Khosla/80e9e3fc3670482c1fee16b2542061b779f47c4f)). 